### PR TITLE
Configuring flake for Notebooks

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -41,7 +41,7 @@ flake8 pybatfish,tests
 echo -e "\n  ..... Running flake8 on jupyter notebooks"
 # Running flake test on generated python script from jupyter notebook(s)
 for file in jupyter_notebooks/*.ipynb; do
-    jupyter nbconvert "$file" --to python --stdout --TemplateExporter.exclude_markdown=True | flake8 - --ignore=E501,W391,D100,F403,F405,F821
+    jupyter nbconvert "$file" --to python --stdout --TemplateExporter.exclude_markdown=True | flake8 - --select=E,W --ignore=E501,W391
 done
 
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -41,7 +41,7 @@ flake8 pybatfish,tests
 echo -e "\n  ..... Running flake8 on jupyter notebooks"
 # Running flake test on generated python script from jupyter notebook(s)
 for file in jupyter_notebooks/*.ipynb; do
-    jupyter nbconvert "$file" --to python --stdout --TemplateExporter.exclude_markdown=True | flake8 - --ignore=E501,W391,D100,F403,F405
+    jupyter nbconvert "$file" --to python --stdout --TemplateExporter.exclude_markdown=True | flake8 - --ignore=E501,W391,D100,F403,F405,F821
 done
 
 


### PR DESCRIPTION
- Since the notebook is importing commands in an external script `startup.py`, flake throws a warning like:
```
stdin:8:1: F821 undefined name 'get_ipython'
stdin:18:1: F821 undefined name 'bf_set_network'
stdin:19:1: F821 undefined name 'bf_init_snapshot'
stdin:31:14: F821 undefined name 'bfq'
stdin:56:11: F821 undefined name 'pd'
```