### PR TITLE
bf_init_snapshot: add overwrite and overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ dist
 .env/
 .env3/
 
+# Jupyter checkpoints
+.ipynb_checkpoints/
+
 # Misc files 
 .DS_Store

--- a/jupyter_notebooks/Getting started with Batfish.ipynb
+++ b/jupyter_notebooks/Getting started with Batfish.ipynb
@@ -67,7 +67,7 @@
     "SNAPSHOT_PATH = \"test_rigs/example\"\n",
     "\n",
     "bf_set_network(NETWORK_NAME)\n",
-    "bf_init_snapshot(SNAPSHOT_PATH, name=SNAPSHOT_NAME)"
+    "bf_init_snapshot(SNAPSHOT_PATH, name=SNAPSHOT_NAME, overwrite=True)"
    ]
   },
   {

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -41,8 +41,6 @@ class Session(object):
         self.apiKey = CoordConsts.DEFAULT_API_KEY  # type: str
         self.network = None  # type: Optional[str]
         self.baseSnapshot = None  # type: Optional[str]
-        # Snapshots is a list of snapshot names
-        self.snapshots = []  # type: List[str]
 
         # Additional worker args
         self.additionalArgs = {}  # type: Dict


### PR DESCRIPTION
- add overwrite arg, in which case an existing snapshot will be deleted
- do as much validation as early as possible. e.g., don't create zip until after.
- delete bf_session.snapshots, in favor of just listing on demand.