### PR TITLE
workhelper: require snapshot set on executed work items

### DIFF
--- a/pybatfish/client/resthelper.py
+++ b/pybatfish/client/resthelper.py
@@ -47,8 +47,8 @@ _requests_session.mount("http", HTTPAdapter(
 #                              'https': 'http://127.0.0.1:8888'}
 
 
-def get_object(session, object_name, snapshot=None):
-    # type: (Session, str, Optional[str]) -> bytes
+def get_object(session, snapshot, object_name):
+    # type: (Session, str, str) -> bytes
     """Execute the getObject RPC call to Batfish.
 
     :param session: :py:class:`~pybatfish.client.session.Session` object to use
@@ -56,7 +56,6 @@ def get_object(session, object_name, snapshot=None):
 
     :rtype: bytes
     """
-    snapshot = session.get_snapshot(snapshot)
     json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
                  CoordConsts.SVC_KEY_CONTAINER_NAME: session.network,
                  CoordConsts.SVC_KEY_TESTRIG_NAME: snapshot,

--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -82,8 +82,15 @@ def execute(work_item, session, background=False):
     a string description of the result. If `background=False`, a dict containing
     "status" and "answer" keys, both strings.
     """
-    json_data = {CoordConsts.SVC_KEY_WORKITEM: work_item.to_json(),
-                 CoordConsts.SVC_KEY_API_KEY: session.apiKey}
+    snapshot = work_item.requestParams.get(BfConsts.ARG_TESTRIG)
+    if snapshot is None:
+        raise ValueError('Work item {} does not include a snapshot name'.format(
+            work_item.to_json()))
+
+    json_data = {
+        CoordConsts.SVC_KEY_WORKITEM: work_item.to_json(),
+        CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    }
 
     # Submit the work item
     response = resthelper.get_json_response(
@@ -113,7 +120,8 @@ def execute(work_item, session, background=False):
 
         # get the answer
         answer_file_name = _compute_batfish_answer_file_name(work_item)
-        answer_bytes = resthelper.get_object(session, answer_file_name)
+        answer_bytes = resthelper.get_object(session, snapshot,
+                                             answer_file_name)
 
         # In Python 3.x, answer needs to be decoded before it can be used
         # for things like json.loads (<= 3.6).


### PR DESCRIPTION
The code expects that there's always a snapshot present on work items. Enforce this, and use the
correct snapshot when fetching logs.

Alternate approach to #37  -- thoughts?