### PR TITLE
Client: cleanup bf_init_snapshot signature and postconditions

### DIFF
--- a/jupyter_notebooks/Getting started with Batfish.ipynb
+++ b/jupyter_notebooks/Getting started with Batfish.ipynb
@@ -47,7 +47,7 @@
     {
      "data": {
       "text/plain": [
-       "'{\\n  \"answerElements\" : [\\n    {\\n      \"class\" : \"org.batfish.datamodel.answers.InitInfoAnswerElement\",\\n      \"parseStatus\" : {\\n        \"as1border1\" : \"PASSED\",\\n        \"as1border2\" : \"PASSED\",\\n        \"as1core1\" : \"PASSED\",\\n        \"as2border1\" : \"PASSED\",\\n        \"as2border2\" : \"PASSED\",\\n        \"as2core1\" : \"PASSED\",\\n        \"as2core2\" : \"PASSED\",\\n        \"as2dept1\" : \"PASSED\",\\n        \"as2dist1\" : \"PASSED\",\\n        \"as2dist2\" : \"PASSED\",\\n        \"as3border1\" : \"PASSED\",\\n        \"as3border2\" : \"PASSED\",\\n        \"as3core1\" : \"PASSED\",\\n        \"host1\" : \"PASSED\",\\n        \"host2\" : \"PASSED\",\\n        \"iptables/host1.iptables\" : \"PASSED\",\\n        \"iptables/host2.iptables\" : \"PASSED\"\\n      }\\n    }\\n  ],\\n  \"status\" : \"SUCCESS\",\\n  \"summary\" : {\\n    \"numFailed\" : 0,\\n    \"numPassed\" : 0,\\n    \"numResults\" : 0\\n  }\\n}\\n'"
+       "'example_snapshot'"
       ]
      },
      "execution_count": 2,

--- a/jupyter_notebooks/Test and Validation.ipynb
+++ b/jupyter_notebooks/Test and Validation.ipynb
@@ -43,7 +43,7 @@
     {
      "data": {
       "text/plain": [
-       "'{\\n  \"answerElements\" : [\\n    {\\n      \"class\" : \"org.batfish.datamodel.answers.InitInfoAnswerElement\",\\n      \"parseStatus\" : {\\n        \"as1border1\" : \"PASSED\",\\n        \"as1border2\" : \"PASSED\",\\n        \"as1core1\" : \"PASSED\",\\n        \"as2border1\" : \"PASSED\",\\n        \"as2border2\" : \"PASSED\",\\n        \"as2core1\" : \"PASSED\",\\n        \"as2core2\" : \"PASSED\",\\n        \"as2dept1\" : \"PASSED\",\\n        \"as2dist1\" : \"PASSED\",\\n        \"as2dist2\" : \"PASSED\",\\n        \"as3border1\" : \"PASSED\",\\n        \"as3border2\" : \"PASSED\",\\n        \"as3core1\" : \"PASSED\",\\n        \"host1\" : \"PASSED\",\\n        \"host2\" : \"PASSED\",\\n        \"iptables/host1.iptables\" : \"PASSED\",\\n        \"iptables/host2.iptables\" : \"PASSED\"\\n      }\\n    }\\n  ],\\n  \"status\" : \"SUCCESS\",\\n  \"summary\" : {\\n    \"numFailed\" : 0,\\n    \"numPassed\" : 0,\\n    \"numResults\" : 0\\n  }\\n}\\n'"
+       "'example_snapshot'"
       ]
      },
      "execution_count": 2,

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -17,7 +17,7 @@
 from __future__ import absolute_import, print_function
 
 from copy import deepcopy
-from inspect import getmembers, isfunction
+from inspect import getmembers
 import json
 import os
 import re

--- a/pybatfish/util.py
+++ b/pybatfish/util.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 import os
 import string
-from typing import Sized, Union  # noqa: F401
+from typing import Any, IO, Sized, Union  # noqa: F401
 import uuid
 import zipfile
 
@@ -154,7 +154,7 @@ def validate_question_name(name):
 
 
 def zip_dir(dir_path, out_file):
-    # type: (str, str) -> None
+    # type: (str, Union[str, IO[Any]]) -> None
     """
     ZIP a specified directory and write it to the given output file path.
 


### PR DESCRIPTION
- if background is True, semantics unchanged
- if initialization fails, then:
   - do not change bf_session settings
   - raise an exception
- if initialization succeeds, return the name of the created
   snapshot (and set bf_session correctly).

includes #39, so ignore that bit. Thoughts on what I think are the improved semantics?