### PR TITLE
Fixing notebook tests

### DIFF
--- a/jupyter_notebooks/Test and Validation.ipynb
+++ b/jupyter_notebooks/Test and Validation.ipynb
@@ -481,8 +481,8 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>node</th>\n",
-       "      <th>extra-ntp-servers</th>\n",
        "      <th>missing-ntp-servers</th>\n",
+       "      <th>extra-ntp-servers</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -527,13 +527,13 @@
        "</div>"
       ],
       "text/plain": [
-       "         node extra-ntp-servers missing-ntp-servers\n",
-       "0  as1border1                {}       {23.23.23.23}\n",
-       "1  as1border2     {18.18.18.18}                  {}\n",
-       "2  as2border1     {18.18.18.18}                  {}\n",
-       "3  as2border2     {18.18.18.18}       {23.23.23.23}\n",
-       "4  as3border1     {18.18.18.18}                  {}\n",
-       "5  as3border2     {18.18.18.18}                  {}"
+       "         node missing-ntp-servers extra-ntp-servers\n",
+       "0  as1border1                  {}     {23.23.23.23}\n",
+       "1  as1border2       {18.18.18.18}                {}\n",
+       "2  as2border1       {18.18.18.18}                {}\n",
+       "3  as2border2       {18.18.18.18}     {23.23.23.23}\n",
+       "4  as3border1       {18.18.18.18}                {}\n",
+       "5  as3border2       {18.18.18.18}                {}"
       ]
      },
      "execution_count": 9,
@@ -545,8 +545,8 @@
     "ns_extra = node_props[COL_NAME].map(lambda x: set(x) - ref_ntp_servers)\n",
     "ns_missing = node_props[COL_NAME].map(lambda x: ref_ntp_servers - set(x))\n",
     "# Let's join these columns up with the node columns for a better view\n",
-    "diff_df = pd.DataFrame({'node': node_props[\"node\"], 'extra-{}'.format(COL_NAME): ns_extra,\n",
-    "                        'missing-{}'.format(COL_NAME): ns_missing})\n",
+    "diff_df = pd.concat([node_props[\"node\"], ns_extra.rename('missing-{}'.format(COL_NAME)),\n",
+    "                     ns_missing.rename('extra-{}'.format(COL_NAME))], axis=1)\n",
     "diff_df"
    ]
   },


### PR DESCRIPTION
Follow-up from batfish/pybatfish#40:
- comparing explicit fields for outputs as comparing the entire output makes the result indeterministic because of the underlying dict structure

- Using `pd.concat` in one of the cells to make the column order deterministic