### PR TITLE
Generalize serialization

### DIFF
--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -22,17 +22,17 @@ import json
 import os
 import re
 import sys
+from typing import Any, Dict, Iterable, List, Optional, Set, Union  # noqa: F401
 
 from six import PY3, integer_types, string_types
-from typing import Any, Dict, Iterable, List, Optional, Set, Union  # noqa: F401
 
 from pybatfish.client.commands import (_bf_answer_obj,
                                        _bf_get_question_templates, bf_logger,
                                        bf_session)
 from pybatfish.exception import QuestionValidationException
 from pybatfish.question import bfq
-from pybatfish.util import (get_uuid, validate_json_path_regex,
-                            validate_question_name)
+from pybatfish.util import BfJsonEncoder, get_uuid, validate_json_path_regex, \
+    validate_question_name
 
 # A set of tags across all questions
 _tags = set()  # type: Set[str]
@@ -44,18 +44,6 @@ __all__ = [
     'load_dir_questions',
     'load_questions',
 ]
-
-
-class _QuestionEncoder(json.JSONEncoder):
-    """A default encoder for Batfish Question objects."""
-
-    def default(self, obj):
-        if isinstance(obj, QuestionBase):
-            # Return the dictionary representation of the Question.
-            return obj.dict()
-
-        # Fall back to default serialization for all other objects.
-        return json.JSONEncoder.default(self, obj)
 
 
 class QuestionMeta(type):
@@ -169,7 +157,7 @@ class QuestionBase(object):
         sort_keys=True and indent=2
         """
         return json.dumps(self._dict, sort_keys=True, indent=2,
-                          cls=_QuestionEncoder, **kwargs)
+                          cls=BfJsonEncoder, **kwargs)
 
     def load(self, moduleName=bfq.__name__):
         """(Re)load this question as a default question."""

--- a/pybatfish/util.py
+++ b/pybatfish/util.py
@@ -23,12 +23,14 @@ import uuid
 import zipfile
 
 from pybatfish.exception import QuestionValidationException
+import simplejson as json
 
 # Max length of snapshot/question names.
 # Not 255 to accommodate potential folders/extensions, etc.
 _MAX_FILENAME_LEN = 150
 
 __all__ = [
+    'BfJsonEncoder',
     'conditional_str',
     'get_uuid',
     'validate_json_path_regex',
@@ -36,6 +38,19 @@ __all__ = [
     'validate_question_name',
     'zip_dir',
 ]
+
+
+class BfJsonEncoder(json.JSONEncoder):
+    """A default encoder for Batfish question and datamodel objects."""
+
+    def default(self, obj):
+        try:
+            # Return the dictionary representation, which is supported by
+            # questions and datamodel elements
+            return obj.dict()
+        except AttributeError:
+            # Fall back to default serialization for all other objects.
+            return json.JSONEncoder.default(self, obj)
 
 
 def conditional_str(prefix, obj, suffix):

--- a/pybatfish/util.py
+++ b/pybatfish/util.py
@@ -22,8 +22,6 @@ from typing import Any, IO, Sized, Union  # noqa: F401
 import uuid
 import zipfile
 
-import jsonpickle
-
 from pybatfish.exception import QuestionValidationException
 
 # Max length of snapshot/question names.
@@ -33,7 +31,6 @@ _MAX_FILENAME_LEN = 150
 __all__ = [
     'conditional_str',
     'get_uuid',
-    'obj_to_str',
     'validate_json_path_regex',
     'validate_name',
     'validate_question_name',
@@ -57,18 +54,6 @@ def get_uuid():
     # type: () -> str
     """Generate and return a UUID as a string."""
     return str(uuid.uuid4())
-
-
-def obj_to_str(object):
-    # type: (object) -> str
-    """Converts an object into its JSON encoding.
-
-    This function is useful for classes that do not implement their own conversion to str or dict.
-    """
-    jsonpickle.set_encoder_options("json",
-                                   indent=2)  # TODO: figure out how to revert the options
-    ret_str = jsonpickle.encode(object, unpicklable=False)  # type: str
-    return ret_str
 
 
 def validate_json_path_regex(s):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 attrs>=18.1.0
 deepdiff
 deprecated
-jsonpickle
 jupyter
 nbconvert
 nbformat

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
     install_requires=['attrs>=18.1.0',
                       'deepdiff',
                       'deprecated',
-                      'jsonpickle',
                       'pandas>=0.23.0',
                       'python-dateutil',
                       'requests',

--- a/tests/datamodel/test_datamodel_element.py
+++ b/tests/datamodel/test_datamodel_element.py
@@ -11,7 +11,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import json
+
 from pybatfish.datamodel import Interface, IssueType
+from pybatfish.util import BfJsonEncoder
 
 
 def test_as_dict():
@@ -19,3 +22,8 @@ def test_as_dict():
         'hostname': 'host', 'interface': 'iface'}
     assert IssueType(major='lazer', minor='coal').dict() == {'major': 'lazer',
                                                              'minor': 'coal'}
+
+
+def test_json_serialization():
+    i = Interface(hostname='host', interface='iface')
+    assert BfJsonEncoder().encode(i) == json.dumps(i.dict())


### PR DESCRIPTION
* Get rid of jsonpickle module
* Move out `_QuestionEncoder` -> `BfJsonEncoder` as a general utility for serializing all question and datamodel classes
* Trivial tests