### PR TITLE
docs: Session's ports match actual defaults

### DIFF
--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -27,8 +27,8 @@ class Session(object):
     """Keeps session configuration needed to connect to a Batfish server.
 
     :ivar coordinatorHost: The host of the batfish service
-    :ivar coordinatorPort: The port batfish service is running on (9996 by default)
-    :ivar coordinatorPort2: The additional port of batfish service (9997 by default)
+    :ivar coordinatorPort: The port batfish service is running on (9997 by default)
+    :ivar coordinatorPort2: The additional port of batfish service (9996 by default)
     :ivar useSsl: Whether to use SSL when connecting to Batfish (False by default)
     :ivar apiKey: Your API key
     """


### PR DESCRIPTION
* Update client.Session coordinatorPort and coordinatorPort2 documentation
  to match those in client.consts (Port is 9997 and Port2 is 9996).