### PR TITLE
Automatic enforcement of documentation quality

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -44,10 +44,13 @@ for file in jupyter_notebooks/*.ipynb; do
     jupyter nbconvert "$file" --to python --stdout --TemplateExporter.exclude_markdown=True | flake8 - --select=E,W --ignore=E501,W391
 done
 
-
 ### Run unit tests that don't require running instance of batfish
 echo -e "\n  ..... Running unit tests with pytest"
 python setup.py test
+
+### Build docs. This will fail on warnings
+echo -e "\n  ..... Building documentation"
+python setup.py build_sphinx
 
 #### Running integration tests (require batfish)
 echo -e "\n  ..... Running python ref tests with batfish"

--- a/docs/generate_questions_doc.py
+++ b/docs/generate_questions_doc.py
@@ -31,7 +31,7 @@ from pybatfish.question import load_dir_questions  # noqa: 402
 from pybatfish.question import bfq  # noqa: 402
 
 
-def _process(line: str) -> str:
+def _process(line):
     return "   " + line
 
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -1,7 +1,0 @@
-Development API
-===============
-
-REST call wrappers
-------------------
-.. automodule:: pybatfish.client.resthelper
-    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,6 @@ for building and running Batfish service.
    questions.rst
    datamodel.rst
    api.rst
-   .. dev.rst
 
 Indices and tables
 ==================

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,71 +1,62 @@
 Getting started
 ===============
 
-To get started with ``Pybatfish``, you will need a network snapshot.  An example snapshot is packaged with ``Pybatfish`` (`link <https://github.com/batfish/pybatfish/tree/master/jupyter_notebooks/networks/example>`_) and can be used to step through the example below.  Alternatively, you can package a snapshot of your own network as described `here <https://github.com/batfish/batfish/wiki/Packaging-snapshots-for-analysis>`_.
+To get started with Pybatfish, you will need a network snapshot.
+An example snapshot is packaged with Pybatfish (`link <https://github.com/batfish/pybatfish/tree/master/jupyter_notebooks/networks/example>`_)
+and can be used to step through the example below.  Alternatively, you can package a snapshot of your own network as described `here <https://github.com/batfish/batfish/wiki/Packaging-snapshots-for-analysis>`_.
 
-The following instructions show how to upload and query a network snapshot using ``Pybatfish`` in an interactive python shell like ``IPython``.  In these instructions, it is assumed that ``Batfish`` is running on the same machine as the ``Pybatfish`` client and the example snapshot included in ``Batfish`` is being analyzed.
+The following instructions show how to upload and query a network snapshot using Pybatfish in an interactive python shell like IPython.
+In these instructions, we assumed that Batfish is running on the same machine as Pybatfish, and the example snapshot included with Pybatfish is being analyzed.
 
-1. Import ``Pybatfish``:
+1. Import Pybatfish:
 
-.. code-block:: python
+>>> from pybatfish.client.commands import *
+>>> from pybatfish.question.question import load_questions, list_questions
+>>> from pybatfish.question import bfq
 
-    from pybatfish.client.commands import *
-    from pybatfish.question.question import load_questions, list_questions
-    from pybatfish.question import bfq
+2. Load the question templates from the Batfish service into Pybatfish:
 
+>>> load_questions()
 
-2. Point the client to where ``Batfish`` service is running:
+4. Upload a network snapshot (you'll see some log messages followed by the
+name of initialized snapshot (prefixed by ``ss_``):
 
-.. code-block:: python
-
-    bf_session.coordinatorHost = 'localhost'
-
-*Note that localhost here should be replaced if the* ``Batfish`` *service is running remotely.*
-
-3. Load the question templates from the ``Batfish`` service into ``Pybatfish``:
-
-.. code-block:: python
-
-    >>> load_questions()
-    Successfully loaded X questions from remote
-
-4. Upload a network snapshot:
-
-.. code-block:: python
-
-    bf_init_snapshot('jupyter_notebooks/networks/example')
+>>> bf_init_snapshot('jupyter_notebooks/networks/example') # doctest: +ELLIPSIS
+'ss_...'
 
 Here, the example network is being uploaded, but this location could also be a folder or a zip containing a custom network snapshot.
 
-5. Ask a question about the snapshot, using one of the loaded templates (``bfq`` holds the questions currently loaded in ``Pybatfish``). For example here, the question ``IPOwners`` fetches the mapping between IP address, interface, node and VRF for all devices in the network. :
+5. Ask a question about the snapshot, using one of the loaded templates (``bfq`` holds the questions currently loaded in Pybatfish).
+For example here, the question ``IPOwners`` fetches the mapping between IP address, interface, node and VRF for all devices in the network. :
 
-.. code-block:: python
+>>> ip_owners_ans = bfq.ipOwners().answer()
 
-    >>> ip_owners_ans = bfq.ipOwners().answer()
-    
-``answer()`` runs the question and returns the answer in a JSON format. See the ``Batfish`` `questions directory <https://github.com/batfish/batfish/tree/master/questions>`_ for the set of questions that can be asked and their parameters.
+``answer()`` runs the question and returns the answer in a JSON format. See the Batfish
+`questions directory <https://github.com/batfish/batfish/tree/master/questions>`_
+for the set of questions that can be asked and their parameters.
 
-6. To print the answer in a nice table, call ``frame()`` which wraps the answer as `pandas dataframe <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html>`_. Calling `head() <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.head.html>`_ on the dataframe will print the first 5 rows. :
+6. To print the answer in a nice table, call ``frame()`` which wraps the answer as `pandas dataframe <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html>`_.
+Calling `head() <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.head.html>`_
+on the dataframe will print the first 5 rows:
 
-.. code-block:: python
+>>> ip_owners_ans.frame().head()
+         Node      VRF           Interface          IP  Mask  Active
+0    as2dist2  default           Loopback0     2.1.3.2    32    True
+1    as2dist1  default           Loopback0     2.1.3.1    32    True
+2    as2dept1  default  GigabitEthernet1/0  2.34.201.4    24    True
+3    as2dept1  default           Loopback0     2.1.1.2    32    True
+4  as3border2  default  GigabitEthernet1/0     3.0.2.1    24    True
 
-    >>> ip_owners_ans.frame().head()
-     Hostname      VRF           Interface          IP  Mask  Active
-    0  as2border1  default  GigabitEthernet1/0   2.12.11.1    24    True
-    1  as2border1  default  GigabitEthernet2/0   2.12.12.1    24    True
-    2  as3border2  default           Loopback0     3.2.2.2    32    True
-    3  as3border1  default  GigabitEthernet1/0  10.23.21.3    24    True
-    4    as2dist2  default  GigabitEthernet0/0   2.23.22.3    24    True
+7. Next, let's ask a question about interfaces. For example, to see all prefixes present on the interface
+``GigabitEthernet0/0`` of the node ``as1border1`` we can use the ``interfaceProperties`` question like below:
 
-7. Next, let's ask a question about interfaces. For example, to see all prefixes present on the interface ``GigabitEthernet0/0`` of the node ``as1border1`` we can use the ``interfaceProperties`` question like below:
+>>> iface_ans = bfq.interfaceProperties(nodes='as1border1', interfaces='GigabitEthernet0/0', properties='all-prefixes').answer()
+>>> iface_ans
+                           Interface
+    0  as1border1:GigabitEthernet0/0
 
-.. code-block:: python
-
-    >>> iface_ans = bfq.interfaceProperties(nodes='as1border1', interfaces='GigabitEthernet0/0', properties='all-prefixes').answer()
-    >>> iface_ans
-                           interface  all-prefixes
-    0  as1border1:GigabitEthernet0/0  [1.0.1.1/24]
+For additional and more in-depth examples, check out the
+`Jupyter Notebooks <https://github.com/batfish/pybatfish/tree/master/jupyter_notebooks>`_.
 
 
 
-For additional and more in-depth examples, check out the `Jupyter Notebooks <https://github.com/batfish/pybatfish/tree/master/jupyter_notebooks>`_.

--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -704,13 +704,15 @@ def bf_read_question_settings(question_class, json_path=None):
     """
     Retrieves the network-wide JSON settings tree for the specified question class.
 
-    :param question_className: The class of question whose settings are to be read
-    :type question_className: string
+    :param question_class: The class of question whose settings are to be read
+    :type question_class: string
     :param json_path: If supplied, return only the subtree reached by successively
-    traversing each key in json_path starting from the root.
+        traversing each key in json_path starting from the root.
     :type json_path: list
+
     """
-    return restv2helper.read_question_settings(bf_session, question_class, json_path)
+    return restv2helper.read_question_settings(bf_session, question_class,
+                                               json_path)
 
 
 def bf_run_analysis(analysisName, snapshot, reference_snapshot=None):
@@ -895,11 +897,13 @@ def bf_write_question_settings(settings, question_class, json_path=None):
     :param question_class: The class of question to configure
     :type question_class: string
     :param json_path: If supplied, write settings to the subtree reached by successively
-    traversing each key in json_path starting from the root. Any absent keys along
-    the path will be created.
+        traversing each key in json_path starting from the root. Any absent keys along
+        the path will be created.
     :type json_path: list
+
     """
-    restv2helper.write_question_settings(bf_session, settings, question_class, json_path)
+    restv2helper.write_question_settings(bf_session, settings, question_class,
+                                         json_path)
 
 
 def _check_network():

--- a/pybatfish/datamodel/flow.py
+++ b/pybatfish/datamodel/flow.py
@@ -215,12 +215,14 @@ class HeaderConstraints(DataModelElement):
     Lists of values in each fields are subject to a logical "OR":
 
     >>> HeaderConstraints(ipProtocols=["TCP", "UDP"])
+    HeaderConstraints(srcIps=None, dstIps=None, srcPorts=None, dstPorts=None, ipProtocols=['TCP', 'UDP'], applications=None, icmpCodes=None, icmpTypes=None, flowStates=None, ecns=None, dscps=None, packetLengths=None, fragmentOffsets=None)
 
     means allow TCP OR UDP.
 
     Different fields are ANDed together:
 
     >>> HeaderConstraints(srcIps="1.1.1.1", dstIps="2.2.2.2", applications=["SSH"])
+    HeaderConstraints(srcIps='1.1.1.1', dstIps='2.2.2.2', srcPorts=None, dstPorts=None, ipProtocols=None, applications=['SSH'], icmpCodes=None, icmpTypes=None, flowStates=None, ecns=None, dscps=None, packetLengths=None, fragmentOffsets=None)
 
     means an SSH connection originating at ``1.1.1.1`` and going to ``2.2.2.2``
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,13 @@ filename = *.py,
 ignore = E501,E731,D501,D100,D101,D102,D103,D104,D105,D106,D107,D401,W503,W504
 
 [tool:pytest]
-testpaths = tests
-addopts = --ignore tests/integration
+testpaths = tests docs pybatfish
+addopts = --ignore tests/integration --doctest-glob='docs/source/*.rst' --doctest-modules
+doctest_encoding = utf8
+doctest_optionflags = NORMALIZE_WHITESPACE ALLOW_UNICODE ALLOW_BYTES
 
+[build_sphinx]
+source-dir = docs/source
+all-files = True
+build-dir = docs/build
+warning-is-error = 1

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,10 @@ from codecs import open
 from os import path
 from sys import version_info
 
-import pybatfish
 # Always prefer setuptools over distutils
 from setuptools import find_packages, setup
+
+import pybatfish
 
 here = path.abspath(path.dirname(__file__))
 PY2 = version_info[0] == 2
@@ -115,8 +116,15 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        'dev': ['check-manifest', 'flake8', 'flake8-docstrings', 'jupyter',
-                'nbformat', 'nbconvert', 'pytz'] + \
+        'dev': ['check-manifest',
+                'flake8',
+                'flake8-docstrings',
+                'jupyter',
+                'nbformat',
+                'nbconvert',
+                'sphinx',
+                'sphinx_rtd_theme',
+                'pytz'] + \
                (['mypy'] if not PY2 else []),
         'test': ['coverage', 'pytz'],
     },


### PR DESCRIPTION
Enable doctest+other cool stuff:
- Doctest enables documentation testing of all RST docs  and module docstrings (both must be written in proper format)
- Doctest is now automated part of `python setup.py test`
- Build docs on travis build, fail if warnings detected (helps people write proper docstrings)
- Update getting started to be more friendly and match proper output
- Fix some existing docstrings
