### PR TITLE
Temp fix build by installing ipython < 7 on travis

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -11,6 +11,9 @@ else
 fi
 
 if [ -n "$TRAVIS_BUILD_DIR" ]; then
+   # Install *older* ipython
+   # See https://github.com/jupyter/jupyter_console/issues/167
+   pip install "ipython<7"
    # Build and install pybatfish
    pip install -e .[dev,test]
    export QUESTIONS_DIR=questions


### PR DESCRIPTION
Really hope this is a temporary issue; 
Affects only new, from scratch installs of jupyter, jupyter-console,  and thus ipython.

cc @sfraint since you were the one who discovered it.