### PR TITLE
TableAnswer: delegate _repr_html_ too

### DIFF
--- a/pybatfish/datamodel/answer/table.py
+++ b/pybatfish/datamodel/answer/table.py
@@ -84,6 +84,9 @@ class TableAnswer(Answer):
     def __repr__(self):
         return repr(self.table_data)
 
+    def _repr_html_(self):
+        return self.table_data._repr_html_()
+
     def __str__(self):
         return str(self.table_data)
 


### PR DESCRIPTION
Per discussion, this makes the notebook rendering nicer when you don't call `.frame()`, and should have no effect on other clients.