### PR TITLE
Replace uses of get_object API call and deprecate it

### DIFF
--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -25,6 +25,7 @@ from imp import new_module
 from typing import Any, Dict, List, Optional, Union  # noqa: F401
 from warnings import warn
 
+import six
 from deprecated import deprecated
 from requests import HTTPError
 
@@ -168,10 +169,24 @@ def _bf_answer_obj(question_str, parameters_str, question_name,
     # Answer the question
     work_item = workhelper.get_workitem_answer(bf_session, question_name,
                                                snapshot, reference_snapshot)
-    answer_dict = workhelper.execute(work_item, bf_session, background)
+    workhelper.execute(work_item, bf_session, background)
+
     if background:
         return work_item.id
-    return answer.from_string(answer_dict["answer"])
+
+    # get the answer
+    answer_bytes = resthelper.get_answer(bf_session, snapshot, question_name,
+                                         reference_snapshot)
+
+    # In Python 3.x, answer needs to be decoded before it can be used
+    # for things like json.loads (<= 3.6).
+    if six.PY3:
+        answer_string = answer_bytes.decode(encoding="utf-8")
+    else:
+        answer_string = answer_bytes
+    answer_obj = json.loads(answer_string)
+
+    return answer.from_string(answer_obj[1]['answer'])
 
 
 def bf_auto_complete(completionType, query, maxSuggestions=None):
@@ -357,35 +372,27 @@ def bf_extract_answer_summary(answerJson):
     return answerJson["summary"]
 
 
-def _bf_generate_dataplane(snapshot):
-    # type: (str) -> Dict[str, str]
-    workItem = workhelper.get_workitem_generate_dataplane(bf_session, snapshot)
-    answerDict = workhelper.execute(workItem, bf_session)
-    return answerDict
-
-
 def bf_generate_dataplane(snapshot=None):
     # type: (Optional[str]) -> str
     """Generates the data plane for the supplied snapshot. If no snapshot argument is given, uses the last snapshot initialized."""
     snapshot = bf_session.get_snapshot(snapshot)
-    answerDict = _bf_generate_dataplane(snapshot)
-    answer = answerDict["answer"]
-    return answer
+
+    work_item = workhelper.get_workitem_generate_dataplane(bf_session, snapshot)
+    answer_dict = workhelper.execute(work_item, bf_session)
+    return str(answer_dict["status"].value)
 
 
-def bf_get_analysis_answers(analysisName, snapshot=None,
+def bf_get_analysis_answers(name, snapshot=None,
                             reference_snapshot=None):
     # type: (str, str, Optional[str]) -> Any
     """Get the answers for a previously asked analysis."""
     snapshot = bf_session.get_snapshot(snapshot)
-    jsonData = workhelper.get_data_get_analysis_answers(bf_session,
-                                                        analysisName, snapshot,
-                                                        reference_snapshot)
-    jsonResponse = resthelper.get_json_response(bf_session,
-                                                CoordConsts.SVC_RSC_GET_ANALYSIS_ANSWERS,
-                                                jsonData)
-    answersDict = json.loads(jsonResponse['answers'])
-    return answersDict
+    json_data = workhelper.get_data_get_analysis_answers(
+        bf_session, name, snapshot, reference_snapshot)
+    json_response = resthelper.get_json_response(
+        bf_session, CoordConsts.SVC_RSC_GET_ANALYSIS_ANSWERS, json_data)
+    answers_dict = json.loads(json_response['answers'])
+    return answers_dict
 
 
 def bf_get_answer(questionName, snapshot, reference_snapshot=None):
@@ -691,15 +698,15 @@ def bf_read_question_settings(question_class, json_path=None):
                                                json_path)
 
 
-def bf_run_analysis(analysisName, snapshot, reference_snapshot=None):
-    # type: (str, str, Optional[str]) -> str
-    workItem = workhelper.get_workitem_run_analysis(bf_session, analysisName,
-                                                    snapshot,
-                                                    reference_snapshot)
-    workAnswer = workhelper.execute(workItem, bf_session)
-    # status = workAnswer["status"]
-    answer = workAnswer["answer"]
-    return answer
+def bf_run_analysis(name, snapshot, reference_snapshot=None):
+    # type: (str, str, Optional[str]) -> Any
+    work_item = workhelper.get_workitem_run_analysis(
+        bf_session, name, snapshot, reference_snapshot)
+    work_answer = workhelper.execute(work_item, bf_session)
+    if work_answer["status"] != WorkStatusCode.TERMINATEDNORMALLY:
+        raise BatfishException("Failed to run analysis")
+
+    return bf_get_analysis_answers(name, snapshot, reference_snapshot)
 
 
 @deprecated("Deprecated in favor of bf_set_network(name)")

--- a/pybatfish/client/consts.py
+++ b/pybatfish/client/consts.py
@@ -220,6 +220,7 @@ class CoordConsts(object):
     SVC_KEY_QUESTION = "question"
     SVC_KEY_QUESTION_LIST = "questionlist"
     SVC_KEY_QUESTION_NAME = "questionname"
+    SVC_KEY_REFERENCE_SNAPSHOT_NAME = "referencesnapshotname"
     SVC_KEY_RESULT = "result"
     SVC_KEY_SETTINGS = "settings"
     SVC_KEY_SNAPSHOT_INFO = "snapshotinfo"

--- a/pybatfish/client/resthelper.py
+++ b/pybatfish/client/resthelper.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, print_function
 from typing import Any, Dict, Optional  # noqa: F401
 
 import requests
+from deprecated import deprecated
 from requests import Response  # noqa: F401
 from requests.adapters import HTTPAdapter
 from requests_toolbelt.multipart.encoder import MultipartEncoder
@@ -25,7 +26,7 @@ from urllib3 import Retry
 from urllib3.exceptions import InsecureRequestWarning
 
 import pybatfish
-from pybatfish.client.consts import CoordConsts
+from pybatfish.client.consts import BfConsts, CoordConsts
 from pybatfish.client.session import Session  # noqa: F401
 from pybatfish.exception import BatfishException
 from .options import Options
@@ -47,6 +48,7 @@ _requests_session.mount("http", HTTPAdapter(
 #                              'https': 'http://127.0.0.1:8888'}
 
 
+@deprecated
 def get_object(session, snapshot, object_name):
     # type: (Session, str, str) -> bytes
     """Execute the getObject RPC call to Batfish.
@@ -55,6 +57,8 @@ def get_object(session, snapshot, object_name):
     :param object_name: the name of the object to retrieve (in a snapshot)
 
     :rtype: bytes
+
+    .. deprecated:: 0.36.0
     """
     json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
                  CoordConsts.SVC_KEY_CONTAINER_NAME: session.network,
@@ -62,6 +66,21 @@ def get_object(session, snapshot, object_name):
                  CoordConsts.SVC_KEY_OBJECT_NAME: object_name}
 
     return _post_data(session, CoordConsts.SVC_RSC_GET_OBJECT, json_data,
+                      stream=False).content
+
+
+def get_answer(session, snapshot, question_name, reference_snapshot=None):
+    # type: (Session, str, str, Optional[str]) -> bytes
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+                 CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
+                 CoordConsts.SVC_KEY_SNAPSHOT_NAME: snapshot,
+                 CoordConsts.SVC_KEY_ENV_NAME: BfConsts.RELPATH_DEFAULT_ENVIRONMENT_NAME,
+                 CoordConsts.SVC_KEY_QUESTION_NAME: question_name,
+                 }
+    if reference_snapshot is not None:
+        json_data[
+            CoordConsts.SVC_KEY_REFERENCE_SNAPSHOT_NAME] = reference_snapshot
+    return _post_data(session, CoordConsts.SVC_RSC_GET_ANSWER, json_data,
                       stream=False).content
 
 

--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -21,7 +21,6 @@ import logging
 import time
 from typing import Any, Dict, Optional  # noqa: F401
 
-import six
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzlocal
@@ -67,7 +66,7 @@ def _print_timestamp(timestamp):
 
 
 def execute(work_item, session, background=False):
-    # type: (WorkItem, Session, bool) -> Dict[str, str]
+    # type: (WorkItem, Session, bool) -> Dict[str, Any]
     """Submit a work item to Batfish.
 
     :param work_item: work to submit
@@ -97,6 +96,8 @@ def execute(work_item, session, background=False):
         session, CoordConsts.SVC_RSC_QUEUE_WORK, json_data)
 
     if background:
+        # TODO: this is ugly and messes with return types: design and write async replacement
+        # After we drop 2.7 support
         return {"result": str(response["result"])}
 
     try:
@@ -117,19 +118,7 @@ def execute(work_item, session, background=False):
             raise BatfishException(
                 "Work finished with status {}\n{}".format(status,
                                                           work_item.to_json()))
-
-        # get the answer
-        answer_file_name = _compute_batfish_answer_file_name(work_item)
-        answer_bytes = resthelper.get_object(session, snapshot,
-                                             answer_file_name)
-
-        # In Python 3.x, answer needs to be decoded before it can be used
-        # for things like json.loads (<= 3.6).
-        if six.PY3:
-            answer_string = answer_bytes.decode(encoding="utf-8")
-        else:
-            answer_string = answer_bytes
-        return {"status": status, "answer": answer_string}
+        return {"status": status}
 
     except KeyboardInterrupt:
         response = kill_work(session, work_item.id)


### PR DESCRIPTION
Switch to using getAnswer and getAnalysis answer instead.

This change should be transparent to users, however it does affect developers a little: `work_helper.execute` method no longer fetches the answer/log produced during the execution of the workitem. 
This means that `dataplaneAnswerElement`, for example, won't be fetched and printed like it was previously, when running `bf_generate_dataplane()`