### PR TITLE
Support for new HeaderConstraint format

### DIFF
--- a/jupyter_notebooks/Provably Safe ACL and Firewall Changes.ipynb
+++ b/jupyter_notebooks/Provably Safe ACL and Firewall Changes.ipynb
@@ -96,7 +96,7 @@
     "change_traffic = HeaderConstraints(srcIps=\"10.10.10.0/24\",\n",
     "                                   dstIps=\"18.18.18.0/27\",\n",
     "                                   ipProtocols=[\"tcp\"],\n",
-    "                                   dstPorts=[80, 8080])"
+    "                                   dstPorts=\"80, 8080\")"
    ]
   },
   {
@@ -342,38 +342,38 @@
      "data": {
       "text/html": [
        "<style  type=\"text/css\" >\n",
-       "    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col0 {\n",
+       "    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col0 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col1 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col1 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col2 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col2 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col3 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col3 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col4 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col4 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col5 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col5 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col6 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col6 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col7 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col7 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col8 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col8 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
-       "        }    #T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col9 {\n",
+       "        }    #T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col9 {\n",
        "            text-align:  left;\n",
        "            vertical-align:  top;\n",
        "        }</style>  \n",
-       "<table id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04d\" > \n",
+       "<table id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849\" > \n",
        "<thead>    <tr> \n",
        "        <th class=\"blank level0\" ></th> \n",
        "        <th class=\"col_heading level0 col0\" >Node</th> \n",
@@ -388,22 +388,22 @@
        "        <th class=\"col_heading level0 col9\" >Delta_Trace</th> \n",
        "    </tr></thead> \n",
        "<tbody>    <tr> \n",
-       "        <th id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04dlevel0_row0\" class=\"row_heading level0 row0\" >0</th> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col0\" class=\"data row0 col0\" >rtr-with-acl</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col1\" class=\"data row0 col1\" >acl_in</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col2\" class=\"data row0 col2\" >start=rtr-with-acl [10.10.10.0:0->18.18.18.32:80 TCP]</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col3\" class=\"data row0 col3\" >In both</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col4\" class=\"data row0 col4\" >PERMIT</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col5\" class=\"data row0 col5\" >DENY</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col6\" class=\"data row0 col6\" >462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col7\" class=\"data row0 col7\" >2020 deny tcp any any</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col8\" class=\"data row0 col8\" >Flow permitted by 'extended ipv4 access-list' named 'acl_in', index 23: 462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80</td> \n",
-       "        <td id=\"T_d1dc9010_c380_11e8_bb06_c4b301cae04drow0_col9\" class=\"data row0 col9\" >Flow denied by 'extended ipv4 access-list' named 'acl_in', index 101: 2020 deny tcp any any</td> \n",
+       "        <th id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849level0_row0\" class=\"row_heading level0 row0\" >0</th> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col0\" class=\"data row0 col0\" >&#x27;rtr-with-acl&#x27;</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col1\" class=\"data row0 col1\" >&#x27;acl_in&#x27;</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col2\" class=\"data row0 col2\" >10.10.10.0:0 &rarr; 18.18.18.32:80<br>start=rtr-with-acl</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col3\" class=\"data row0 col3\" >&#x27;In both&#x27;</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col4\" class=\"data row0 col4\" >&#x27;PERMIT&#x27;</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col5\" class=\"data row0 col5\" >&#x27;DENY&#x27;</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col6\" class=\"data row0 col6\" >&#x27;462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80&#x27;</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col7\" class=\"data row0 col7\" >&#x27;2020 deny tcp any any&#x27;</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col8\" class=\"data row0 col8\" >AclTrace(events=[AclTraceEvent(class_name=&#x27;org.batfish.datamodel.acl.PermittedByIpAccessListLine&#x27;, description=&quot;Flow permitted by &#x27;extended ipv4 access-list&#x27; named &#x27;acl_in&#x27;, index 23: 462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80&quot;, lineDescription=&#x27;462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80&#x27;)])</td> \n",
+       "        <td id=\"T_3d2e4446_d17b_11e8_871b_8c85902fd849row0_col9\" class=\"data row0 col9\" >AclTrace(events=[AclTraceEvent(class_name=&#x27;org.batfish.datamodel.acl.DeniedByIpAccessListLine&#x27;, description=&quot;Flow denied by &#x27;extended ipv4 access-list&#x27; named &#x27;acl_in&#x27;, index 101: 2020 deny tcp any any&quot;, lineDescription=&#x27;2020 deny tcp any any&#x27;)])</td> \n",
        "    </tr></tbody> \n",
        "</table> "
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x1116ca128>"
+       "<pandas.io.formats.style.Styler at 0x11c9176d8>"
       ]
      },
      "metadata": {},
@@ -705,6 +705,7 @@
   }
  ],
  "metadata": {
+  "hide_input": false,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -720,7 +721,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/pybatfish/datamodel/flow.py
+++ b/pybatfish/datamodel/flow.py
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import re
-from typing import Any, Dict, List, Optional  # noqa: F401
+from typing import Any, Dict, Iterable, List, Optional  # noqa: F401
 
 import attr
 
@@ -349,6 +349,16 @@ class MatchTcpFlags(DataModelElement):
             json_dict['useUrg'])
 
 
+def _normalize_phc_strings(value):
+    # type: (Any) -> Optional[str]
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, Iterable):
+        result = ",".join(value)  # type: str
+        return result
+    raise ValueError("Invalid value {}".format(value))
+
+
 @attr.s(frozen=True)
 class HeaderConstraints(DataModelElement):
     """Constraints on an IPv4 packet header space.
@@ -360,8 +370,8 @@ class HeaderConstraints(DataModelElement):
     :vartype srcIps: str
     :ivar dstIps: Destination location/IP
     :vartype dstIps: str
-    :ivar srcPorts: Source ports as list of ranges (e.g., ``["22-22", "53-99"]``)
-    :ivar dstPorts: Destination ports as list of ranges, (e.g., ``["22-22", "53-99"]``)
+    :ivar srcPorts: Source ports as list of ranges (e.g., ``"22,53-99"``)
+    :ivar dstPorts: Destination ports as list of ranges, (e.g., ``"22,53-99"``)
     :ivar applications: Shorthands for application protocols (e.g., ``SSH``, ``DNS``, ``SNMP``)
     :ivar ipProtocols: List of well-known IP protocols (e.g., ``TCP``, ``UDP``, ``ICMP``)
     :ivar icmpCodes: List of integer ICMP codes
@@ -397,18 +407,26 @@ class HeaderConstraints(DataModelElement):
     # Order params in likelihood of specification
     srcIps = attr.ib(default=None, type=Optional[str])
     dstIps = attr.ib(default=None, type=Optional[str])
-    srcPorts = attr.ib(default=None, type=Optional[List[str]])
-    dstPorts = attr.ib(default=None, type=Optional[List[str]])
+    srcPorts = attr.ib(default=None, type=Optional[str],
+                       converter=_normalize_phc_strings)
+    dstPorts = attr.ib(default=None, type=Optional[str],
+                       converter=_normalize_phc_strings)
     ipProtocols = attr.ib(default=None, type=Optional[List[str]])
     applications = attr.ib(default=None, type=Optional[List[str]])
-    icmpCodes = attr.ib(default=None, type=Optional[List[str]])
-    icmpTypes = attr.ib(default=None, type=Optional[List[str]])
+    icmpCodes = attr.ib(default=None, type=Optional[str],
+                        converter=_normalize_phc_strings)
+    icmpTypes = attr.ib(default=None, type=Optional[str],
+                        converter=_normalize_phc_strings)
     flowStates = attr.ib(default=None, type=Optional[List[str]])
-    ecns = attr.ib(default=None, type=Optional[List[str]])
-    dscps = attr.ib(default=None, type=Optional[List[str]])
-    packetLengths = attr.ib(default=None, type=Optional[List[str]])
-    fragmentOffsets = attr.ib(default=None, type=Optional[List[str]])
-    tcpFlags = attr.ib(default=None, type=Optional[List[MatchTcpFlags]])
+    ecns = attr.ib(default=None, type=Optional[str],
+                   converter=_normalize_phc_strings)
+    dscps = attr.ib(default=None, type=Optional[str],
+                    converter=_normalize_phc_strings)
+    packetLengths = attr.ib(default=None, type=Optional[str],
+                            converter=_normalize_phc_strings)
+    fragmentOffsets = attr.ib(default=None, type=Optional[str],
+                              converter=_normalize_phc_strings)
+    tcpFlags = attr.ib(default=None, type=Optional[MatchTcpFlags])
 
     @classmethod
     def from_dict(cls, json_dict):


### PR DESCRIPTION
To keep up with batfish/batfish#2462
Change is backwards compatible in the sense that it allows old specification using list of strings and new specification as string of comma-separated values.