### PR TITLE
Remove validation of JsonPath regexes

### DIFF
--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -32,8 +32,7 @@ from pybatfish.client.commands import (_bf_answer_obj,
                                        bf_session)
 from pybatfish.exception import QuestionValidationException
 from pybatfish.question import bfq
-from pybatfish.util import BfJsonEncoder, get_uuid, validate_json_path_regex, \
-    validate_question_name
+from pybatfish.util import BfJsonEncoder, get_uuid, validate_question_name
 
 # A set of tags across all questions
 _tags = set()  # type: Set[str]
@@ -662,7 +661,7 @@ def _validateType(value, expectedType):
         if not isinstance(value, string_types):
             return False, "A Batfish {} must be a string".format(
                 expectedType)
-        return validate_json_path_regex(value), None
+        return True, None
     elif expectedType == 'long':
         INT64_MIN = -2 ** 64
         INT64_MAX = 2 ** 64 - 1

--- a/pybatfish/util.py
+++ b/pybatfish/util.py
@@ -39,7 +39,6 @@ __all__ = [
     'escape_html',
     'get_html',
     'get_uuid',
-    'validate_json_path_regex',
     'validate_name',
     'validate_question_name',
     'zip_dir',
@@ -82,26 +81,6 @@ def get_uuid():
     # type: () -> str
     """Generate and return a UUID as a string."""
     return str(uuid.uuid4())
-
-
-def validate_json_path_regex(s):
-    # type: (str) -> bool
-    """Check if the given string is a valid JsonPath regex.
-
-    :param s: string to check
-    :type s: str
-    :return True if `s` is valid
-    :raises QuestionValidationException if `s` is not valid
-    """
-    if not s.startswith('/'):
-        raise QuestionValidationException(
-            "Expected '/' at the start of JsonPath regex")
-
-    if not (s.endswith('/i') or s.endswith('/')):
-        raise QuestionValidationException(
-            "JsonPath regex must end with either '/' or '/i'")
-
-    return True
 
 
 def validate_name(name, entity_type="snapshot"):

--- a/tests/question/test_question.py
+++ b/tests/question/test_question.py
@@ -20,17 +20,6 @@ from pybatfish.exception import QuestionValidationException
 from pybatfish.question.question import (_compute_docstring, _compute_var_help,
                                          _process_variables, _validate,
                                          list_questions, load_questions)
-from pybatfish.util import validate_json_path_regex
-
-
-def test_validate_json_path_regex():
-    assert validate_json_path_regex("/x/")
-    assert validate_json_path_regex("/x/i")
-    assert validate_json_path_regex("/\w+\d.*/i")
-    with pytest.raises(QuestionValidationException):
-        assert validate_json_path_regex("foo")
-    with pytest.raises(QuestionValidationException):
-        assert validate_json_path_regex("/foo")
 
 
 def test_min_length():

--- a/tests/question/test_question_additional.py
+++ b/tests/question/test_question_additional.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import, print_function
 import pytest
 
 # Tests for isSubRange
-from pybatfish.exception import QuestionValidationException
 from pybatfish.question import question
 
 
@@ -354,20 +353,6 @@ def testValidJsonPathValidateType():
                                     'jsonPath')
     assert result[0]
     assert result[1] is None
-
-
-def testInvalidStartJsonPathRegexValidateType():
-    with pytest.raises(QuestionValidationException):
-        question._validateType('jsonPathRegex/', 'jsonPathRegex')
-
-
-def testInvalidEndJsonPathRegexValidateType():
-    with pytest.raises(QuestionValidationException):
-        question._validateType('/jsonPathRegex', 'jsonPathRegex')
-
-
-def testValidJsonPathRegexValidateType():
-    assert question._validateType('/jsonPathRegex/', 'jsonPathRegex')
 
 
 def testInvalidTypeSubRangeValidateType():


### PR DESCRIPTION
Since JsonPath isn't used anymore and validating these in python land was error prone anyway.