### PR TITLE
Print Java log upon bf_init_snapshot failure

### DIFF
--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -598,10 +598,10 @@ def bf_init_snapshot(upload, name=None, overwrite=False, background=False):
 
     status = WorkStatusCode(answer_dict["status"])
     if status != WorkStatusCode.TERMINATEDNORMALLY:
+        init_log = restv2helper.get_work_log(bf_session, name, work_item.id)
         raise BatfishException(
-            'Initializing snapshot {ss} failed with status {status}'.format(
-                ss=name,
-                status=status))
+            'Initializing snapshot {ss} failed with status {status}\n{log}'.format(
+                ss=name, status=status, log=init_log))
     else:
         bf_session.baseSnapshot = name
         bf_logger.info("Default snapshot is now set to %s",

--- a/pybatfish/client/consts.py
+++ b/pybatfish/client/consts.py
@@ -269,6 +269,7 @@ class CoordConsts(object):
     SVC_RSC_GET_PARSING_RESULTS = "getparsingresults"
     SVC_RSC_GET_PARSING_WORK = "getparsingwork"
     SVC_RSC_GET_QUESTION_TEMPLATES = "getquestiontemplates"
+    SVC_RSC_GET_WORKLOG = "getworklog"
     SVC_RSC_GET_WORKSTATUS = "getworkstatus"
     SVC_RSC_GETSTATUS = "getstatus"
     SVC_RSC_INIT_CONTAINER = "initcontainer"
@@ -324,3 +325,4 @@ class CoordConstsV2(object):
     RSC_REFERENCE_LIBRARY = "referencelibrary"
     RSC_SETTINGS = "settings"
     RSC_SNAPSHOTS = "snapshots"
+    RSC_WORK_LOG = "worklog"

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, print_function
 from typing import Any, Dict, List, Optional, Text, Union  # noqa: F401
 
 import requests
+import six
 from requests import HTTPError, Response  # noqa: F401
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
@@ -276,7 +277,7 @@ def get_snapshot_node_role_dimension(session, dimension):
 
 
 def get_work_log(session, snapshot, work_id):
-    # type: (Session, Text, Text) -> str
+    # type: (Session, str, str) -> Text
     """Retrieve the log for a work item with a given ID."""
     if not session.network:
         raise ValueError("Network must be set to get node roles")
@@ -286,7 +287,7 @@ def get_work_log(session, snapshot, work_id):
         CoordConstsV2.RSC_SNAPSHOTS, snapshot,
         CoordConstsV2.RSC_WORK_LOG, work_id)
 
-    return str(_get(session, url_tail, dict()).text)
+    return six.u(_get(session, url_tail, dict()).text)
 
 
 def put_node_roles(session, node_roles_data):

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import, print_function
 
-from typing import Any, Dict, List, Optional, Union  # noqa: F401
+from typing import Any, Dict, List, Optional, Text, Union  # noqa: F401
 
 import requests
 from requests import HTTPError, Response  # noqa: F401
@@ -273,6 +273,20 @@ def get_snapshot_node_role_dimension(session, dimension):
                                            CoordConstsV2.RSC_NODE_ROLES,
                                            dimension)
     return _get_dict(session, url_tail)
+
+
+def get_work_log(session, snapshot, work_id):
+    # type: (Session, Text, Text) -> str
+    """Retrieve the log for a work item with a given ID."""
+    if not session.network:
+        raise ValueError("Network must be set to get node roles")
+
+    url_tail = "/{}/{}/{}/{}/{}/{}".format(
+        CoordConstsV2.RSC_NETWORKS, session.network,
+        CoordConstsV2.RSC_SNAPSHOTS, snapshot,
+        CoordConstsV2.RSC_WORK_LOG, work_id)
+
+    return str(_get(session, url_tail, dict()).text)
 
 
 def put_node_roles(session, node_roles_data):


### PR DESCRIPTION
Admittedly, a very developer-centric behavior but needed until we have better designed APIs.

Tested manually to avoid crafting and checking in failure configs.