### PR TITLE
Handle another failed task status

### DIFF
--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -425,8 +425,8 @@ def print_work_status(session, work_status, task_details):
 
 
 def _print_work_status(session, work_status, task_details, now_function):
-    effective_level = session.logger.getEffectiveLevel()
-    if effective_level in [logging.INFO, logging.DEBUG]:
+    if session.logger.getEffectiveLevel() == logging.INFO \
+            or session.logger.getEffectiveLevel() == logging.DEBUG:
         session.logger.info("status: {}".format(work_status))
 
         json_task = json.loads(task_details)

--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -114,10 +114,14 @@ def execute(work_item, session, background=False):
 
         print_work_status(session, status, task_details)
 
-        if status == WorkStatusCode.ASSIGNMENTERROR:
+        if status in [WorkStatusCode.ASSIGNMENTERROR,
+                      WorkStatusCode.REQUEUEFAILURE]:
             raise BatfishException(
-                "Work finished with status {}\n{}".format(status,
-                                                          work_item.to_json()))
+                "Work finished with status {}\nwork_item: {}\ntask_details: {}".format(
+                    status,
+                    work_item.to_json(),
+                    json.loads(
+                        task_details)))
         return {"status": status}
 
     except KeyboardInterrupt:
@@ -421,8 +425,8 @@ def print_work_status(session, work_status, task_details):
 
 
 def _print_work_status(session, work_status, task_details, now_function):
-    if session.logger.getEffectiveLevel() == logging.INFO \
-            or session.logger.getEffectiveLevel() == logging.DEBUG:
+    effective_level = session.logger.getEffectiveLevel()
+    if effective_level in [logging.INFO, logging.DEBUG]:
         session.logger.info("status: {}".format(work_status))
 
         json_task = json.loads(task_details)


### PR DESCRIPTION
Catch requeue failures (e.g. implicit dataplane generation fails) and add more exception details.  It's not very pretty, but gives some much needed insight into these sort of failures.

For example, with https://github.com/batfish/batfish/pull/2630:
```
>>> bfq.traceroute(...) # Fails implicit dataplane generation
{'answerElements': [{'class': 'org.batfish.datamodel.answers.StringAnswerElement',
   'answer': 'Not answered'}],
 'status': 'NOTFOUND',
 'summary': {'numFailed': 0, 'numPassed': 0, 'numResults': 0}}
```
becomes:
```
>>> bfq.traceroute(...) # Fails implicit dataplane generation
BatfishException: Work finished with status REQUEUEFAILURE
work_item: {"containerName": "example_network", "id": "51db944d-21e1-47ef-bc23-6c049773f249", "requestParams": {"answer": "", "questionname": "__traceroute_7154f49b-c7e1-4c5a-accd-3a18d6ed2cc4", "testrig": "example_snapshot", "env": "env_default"}, "testrigName": "example_snapshot"}
task_details: {'batches': [{'completed': 0, 'description': "Couldn't requeue after unblocking.\nCannot queue dataplane dependent work for 875d8e61-9148-41a8-8323-837facf8c7de: Status is DATAPLANING_FAIL but no incomplete dataplaning work exists", 'size': 0, 'startDate': '2018-11-14T01:09:07.552+0000'}], 'obtained': '2018-11-14T01:09:07.552+0000', 'status': 'RequeueFailure'}
```