### PR TITLE
Simplify (pull up) datamodel imports

### DIFF
--- a/pybatfish/datamodel/__init__.py
+++ b/pybatfish/datamodel/__init__.py
@@ -12,5 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from .acl import *  # noqa: F401,F403
+from .flow import *  # noqa: F401,F403
 from .primitives import *  # noqa: F401,F403
 from .referencelibrary import *  # noqa: F401,F403


### PR DESCRIPTION
This enables one `from pybatfish.datamodel import *` statement to get all datamodel classes.