### PR TITLE
Split internal func out from commands

### DIFF
--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -27,7 +27,6 @@ import six
 from requests import HTTPError
 
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
-from pybatfish.datamodel import answer
 from pybatfish.datamodel.primitives import (  # noqa: F401
     Edge, Interface)
 from pybatfish.datamodel.referencelibrary import (NodeRoleDimension,
@@ -39,7 +38,7 @@ from pybatfish.util import (BfJsonEncoder, get_uuid, validate_name, zip_dir)
 from . import resthelper, restv2helper, workhelper
 from .options import Options
 from .session import Session
-from .workhelper import (_get_data_get_question_templates, get_work_status,
+from .workhelper import (get_work_status,
                          kill_work)
 
 # TODO: normally libraries don't configure logging in code
@@ -138,44 +137,6 @@ def bf_add_reference_book(book):
     :type book: :class:`pybatfish.datamodel.referencelibrary.ReferenceBook`
     """
     restv2helper.add_reference_book(bf_session, book)
-
-
-def _bf_answer_obj(question_str, parameters_str, question_name,
-                   background, snapshot, reference_snapshot):
-    # type: (str, str, str, bool, str, Optional[str]) -> Union[str, Dict]
-
-    json.loads(parameters_str)  # a syntactic check for parametersStr
-    if not question_name:
-        question_name = Options.default_question_prefix + "_" + get_uuid()
-
-    # Upload the question
-    json_data = workhelper.get_data_upload_question(bf_session, question_name,
-                                                    question_str,
-                                                    parameters_str)
-    resthelper.get_json_response(bf_session,
-                                 CoordConsts.SVC_RSC_UPLOAD_QUESTION, json_data)
-
-    # Answer the question
-    work_item = workhelper.get_workitem_answer(bf_session, question_name,
-                                               snapshot, reference_snapshot)
-    workhelper.execute(work_item, bf_session, background)
-
-    if background:
-        return work_item.id
-
-    # get the answer
-    answer_bytes = resthelper.get_answer(bf_session, snapshot, question_name,
-                                         reference_snapshot)
-
-    # In Python 3.x, answer needs to be decoded before it can be used
-    # for things like json.loads (<= 3.6).
-    if six.PY3:
-        answer_string = answer_bytes.decode(encoding="utf-8")
-    else:
-        answer_string = answer_bytes
-    answer_obj = json.loads(answer_string)
-
-    return answer.from_string(answer_obj[1]['answer'])
 
 
 def bf_auto_complete(completionType, query, maxSuggestions=None):
@@ -613,14 +574,6 @@ def bf_list_snapshots(verbose=False):
         snapshots and metadata (if `verbose=True`)
     """
     return restv2helper.list_snapshots(bf_session, verbose)
-
-
-def _bf_get_question_templates():
-    jsonData = _get_data_get_question_templates(bf_session)
-    jsonResponse = resthelper.get_json_response(bf_session,
-                                                CoordConsts.SVC_RSC_GET_QUESTION_TEMPLATES,
-                                                jsonData)
-    return jsonResponse[CoordConsts.SVC_KEY_QUESTION_LIST]
 
 
 def bf_put_node_roles(node_roles_data):

--- a/pybatfish/client/internal.py
+++ b/pybatfish/client/internal.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+#   Copyright 2018 The Batfish Open Source Project
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Contains internal functions for interacting with the Batfish service."""
+
+import json
+from typing import Dict, Optional, Union  # noqa: F401
+
+import six
+
+from pybatfish.client.consts import CoordConsts
+from pybatfish.datamodel import answer
+from pybatfish.util import (get_uuid)
+from . import resthelper, workhelper
+from .options import Options
+from .workhelper import _get_data_get_question_templates
+
+
+def _bf_answer_obj(question_str, parameters_str, question_name,
+                   background, snapshot, reference_snapshot):
+    # type: (str, str, str, bool, str, Optional[str]) -> Union[str, Dict]
+    from pybatfish.client.commands import bf_session
+
+    json.loads(parameters_str)  # a syntactic check for parametersStr
+    if not question_name:
+        question_name = Options.default_question_prefix + "_" + get_uuid()
+
+    # Upload the question
+    json_data = workhelper.get_data_upload_question(bf_session, question_name,
+                                                    question_str,
+                                                    parameters_str)
+    resthelper.get_json_response(bf_session,
+                                 CoordConsts.SVC_RSC_UPLOAD_QUESTION, json_data)
+
+    # Answer the question
+    work_item = workhelper.get_workitem_answer(bf_session, question_name,
+                                               snapshot, reference_snapshot)
+    workhelper.execute(work_item, bf_session, background)
+
+    if background:
+        return work_item.id
+
+    # get the answer
+    answer_bytes = resthelper.get_answer(bf_session, snapshot, question_name,
+                                         reference_snapshot)
+
+    # In Python 3.x, answer needs to be decoded before it can be used
+    # for things like json.loads (<= 3.6).
+    if six.PY3:
+        answer_string = answer_bytes.decode(encoding="utf-8")
+    else:
+        answer_string = answer_bytes
+    answer_obj = json.loads(answer_string)
+
+    return answer.from_string(answer_obj[1]['answer'])
+
+
+def _bf_get_question_templates():
+    from pybatfish.client.commands import bf_session
+    jsonData = _get_data_get_question_templates(bf_session)
+    jsonResponse = resthelper.get_json_response(bf_session,
+                                                CoordConsts.SVC_RSC_GET_QUESTION_TEMPLATES,
+                                                jsonData)
+    return jsonResponse[CoordConsts.SVC_KEY_QUESTION_LIST]

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -17,20 +17,21 @@
 from __future__ import absolute_import, print_function
 
 import json
+import logging
 import os
 import re
 import sys
 from copy import deepcopy
 from inspect import getmembers
-from typing import (Any, Dict, Iterable, List, Optional, Set, Tuple, Union)  # noqa: F401
+from typing import (Any, Dict, Iterable, List, Optional, Set, Tuple,
+                    Union)  # noqa: F401
 
 import attr
 import six
 from six import PY3, integer_types, string_types
 
-from pybatfish.client.commands import (_bf_answer_obj,
-                                       _bf_get_question_templates, bf_logger,
-                                       bf_session)
+from pybatfish.client.internal import (_bf_answer_obj,
+                                       _bf_get_question_templates)
 from pybatfish.datamodel import Assertion, AssertionType  # noqa: F401
 from pybatfish.exception import QuestionValidationException
 from pybatfish.question import bfq
@@ -46,6 +47,8 @@ __all__ = [
     'load_dir_questions',
     'load_questions',
 ]
+
+bf_logger = logging.getLogger("pybatfish.client")
 
 
 @attr.s(frozen=True)
@@ -149,6 +152,7 @@ class QuestionBase(object):
 
         :raises QuestionValidationException: if the question is malformed
         """
+        from pybatfish.client.commands import bf_session
         snapshot = bf_session.get_snapshot(snapshot)
         if reference_snapshot is None and self.get_differential():
             raise ValueError(

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -23,8 +23,8 @@ import re
 import sys
 from copy import deepcopy
 from inspect import getmembers
-from typing import (Any, Dict, Iterable, List, Optional, Set, Tuple,
-                    Union)  # noqa: F401
+from typing import (Any, Dict, Iterable, List, Optional, Set,  # noqa: F401
+                    Tuple, Union)
 
 import attr
 import six


### PR DESCRIPTION
* Relocate some internal functions from `commands.py` to `internal.py`
* Get reference to logger inside of `question.py`
* Use function imports in a few places to help remove circular dependencies

This eliminates `question.py`'s dependency on `commands.py`
