### PR TITLE
pybatfish: fix mutable default args and unused params

### DIFF
--- a/pybatfish/client/diagnostics.py
+++ b/pybatfish/client/diagnostics.py
@@ -29,7 +29,8 @@ from requests import HTTPError
 from pybatfish.exception import BatfishException
 from pybatfish.question.question import QuestionBase
 
-_INIT_INFO_QUESTIONS = [
+# Note: this is a Tuple to enforce immutability.
+_INIT_INFO_QUESTIONS = (
     QuestionBase({
         "class": "org.batfish.question.initialization.ParseWarningQuestion",
         "differential": False,
@@ -51,7 +52,7 @@ _INIT_INFO_QUESTIONS = [
             "instanceName": "__viConversionWarning",
         }
     }),
-]
+)
 
 _S3_BUCKET = 'batfish-diagnostics'
 _S3_REGION = 'us-west-2'
@@ -60,7 +61,7 @@ bf_logger = logging.getLogger("pybatfish.client")
 
 
 def _upload_diagnostics(bucket=_S3_BUCKET, region=_S3_REGION, dry_run=True,
-                        netconan_config=None, questions=None):
+                        netconan_config=None, questions=_INIT_INFO_QUESTIONS):
     # type: (str, str, bool, Optional[str], Optional[List[QuestionBase]]) -> str
     """
     Fetch, anonymize, and optionally upload snapshot initialization information.
@@ -79,8 +80,6 @@ def _upload_diagnostics(bucket=_S3_BUCKET, region=_S3_REGION, dry_run=True,
     :rtype: string
     """
     from pybatfish.client.commands import bf_session
-    if questions is None:
-        questions = _INIT_INFO_QUESTIONS
 
     tmp_dir = tempfile.mkdtemp()
     try:

--- a/pybatfish/client/diagnostics.py
+++ b/pybatfish/client/diagnostics.py
@@ -60,8 +60,8 @@ bf_logger = logging.getLogger("pybatfish.client")
 
 
 def _upload_diagnostics(bucket=_S3_BUCKET, region=_S3_REGION, dry_run=True,
-                        netconan_config=None, questions=_INIT_INFO_QUESTIONS):
-    # type: (str, str, bool, str, List[QuestionBase]) -> str
+                        netconan_config=None, questions=None):
+    # type: (str, str, bool, Optional[str], Optional[List[QuestionBase]]) -> str
     """
     Fetch, anonymize, and optionally upload snapshot initialization information.
 
@@ -79,6 +79,8 @@ def _upload_diagnostics(bucket=_S3_BUCKET, region=_S3_REGION, dry_run=True,
     :rtype: string
     """
     from pybatfish.client.commands import bf_session
+    if questions is None:
+        questions = _INIT_INFO_QUESTIONS
 
     tmp_dir = tempfile.mkdtemp()
     try:

--- a/pybatfish/client/diagnostics.py
+++ b/pybatfish/client/diagnostics.py
@@ -20,7 +20,7 @@ import shutil
 import tempfile
 import uuid
 from hashlib import md5
-from typing import Dict, List, Optional  # noqa: F401
+from typing import Dict, Iterable, Optional  # noqa: F401
 
 import requests
 from netconan import netconan
@@ -62,7 +62,7 @@ bf_logger = logging.getLogger("pybatfish.client")
 
 def _upload_diagnostics(bucket=_S3_BUCKET, region=_S3_REGION, dry_run=True,
                         netconan_config=None, questions=_INIT_INFO_QUESTIONS):
-    # type: (str, str, bool, Optional[str], Optional[List[QuestionBase]]) -> str
+    # type: (str, str, bool, Optional[str], Iterable[QuestionBase]) -> str
     """
     Fetch, anonymize, and optionally upload snapshot initialization information.
 

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -425,7 +425,7 @@ def _delete(session, url_tail, params=None):
 
 
 def _get(session, url_tail, params, stream=False):
-    # type: (Session, str, Dict[str, Any], bool) -> Any
+    # type: (Session, str, Optional[Dict[str, Any]], bool) -> Any
     """Make an HTTP(s) GET request to Batfish coordinator.
 
     :raises SSLError if SSL connection failed
@@ -444,7 +444,7 @@ def _get(session, url_tail, params, stream=False):
 
 
 def _get_dict(session, url_tail, params=None):
-    # type: (Session, str, Dict[str, Any]) -> Dict[str, Any]
+    # type: (Session, str, Optional[Dict[str, Any]]) -> Dict[str, Any]
     """Make an HTTP(s) GET request to Batfish coordinator that should return a JSON dict.
 
     :raises SSLError if SSL connection failed

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -407,7 +407,7 @@ def _check_response_status(response):
         raise HTTPError("{}. {}".format(e, response.text), response=response)
 
 
-def _delete(session, url_tail, params={}):
+def _delete(session, url_tail, params=None):
     # type: (Session, str, Dict[str, Any]) -> None
     """Make an HTTP(s) DELETE request to Batfish coordinator.
 
@@ -443,7 +443,7 @@ def _get(session, url_tail, params, stream=False):
     return response
 
 
-def _get_dict(session, url_tail, params={}):
+def _get_dict(session, url_tail, params=None):
     # type: (Session, str, Dict[str, Any]) -> Dict[str, Any]
     """Make an HTTP(s) GET request to Batfish coordinator that should return a JSON dict.
 
@@ -454,7 +454,7 @@ def _get_dict(session, url_tail, params={}):
     return dict(response.json())
 
 
-def _get_list(session, url_tail, params={}):
+def _get_list(session, url_tail, params=None):
     # type: (Session, str, Dict[str, Any]) -> List
     """Make an HTTP(s) GET request to Batfish coordinator that should return a JSON list.
 
@@ -465,7 +465,7 @@ def _get_list(session, url_tail, params={}):
     return list(response.json())
 
 
-def _get_stream(session, url_tail, params={}):
+def _get_stream(session, url_tail, params=None):
     # type: (Session, str, Dict[str, Any]) -> Any
     """Make an HTTP(s) GET request to Batfish coordinator that should return a raw stream.
 
@@ -477,7 +477,7 @@ def _get_stream(session, url_tail, params={}):
     return response.raw
 
 
-def _post(session, url_tail, obj, params={}):
+def _post(session, url_tail, obj, params=None):
     # type: (Session, str, Any, Dict[str, Any]) -> None
     """Make an HTTP(s) POST request to Batfish coordinator.
 
@@ -496,8 +496,8 @@ def _post(session, url_tail, obj, params={}):
     return None
 
 
-def _put(session, url_tail, obj, params={}, json=None, stream=None):
-    # type: (Session, str, Any, Dict[str, Any], Any, Any) -> None
+def _put(session, url_tail, params=None, json=None, stream=None):
+    # type: (Session, str, Optional[Dict[str, Any]], Optional[Any], Optional[Any]) -> None
     """Make an HTTP(s) PUT request to Batfish coordinator.
 
     :raises SSLError if SSL connection failed
@@ -518,21 +518,21 @@ def _put(session, url_tail, obj, params={}, json=None, stream=None):
     return None
 
 
-def _put_json(session, url_tail, obj, params={}):
+def _put_json(session, url_tail, obj, params=None):
     # type: (Session, str, Any, Dict[str, Any]) -> None
     """Make an HTTP(s) PUT request to Batfish coordinator.
 
     :raises SSLError if SSL connection failed
     :raises ConnectionError if the coordinator is not available
     """
-    _put(session, url_tail, obj, params=params, json=_encoder.default(obj))
+    _put(session, url_tail, params=params, json=_encoder.default(obj))
 
 
-def _put_stream(session, url_tail, stream, params={}):
+def _put_stream(session, url_tail, stream, params=None):
     # type: (Session, str, Any, Dict[str, Any]) -> None
     """Make an HTTP(s) PUT request to Batfish coordinator.
 
     :raises SSLError if SSL connection failed
     :raises ConnectionError if the coordinator is not available
     """
-    _put(session, url_tail, stream, params=params, stream=stream)
+    _put(session, url_tail, params=params, stream=stream)


### PR DESCRIPTION
1. Fix mutable default args (see: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)
2. Remove unused parameter