### PR TITLE
Fix color for delivered to subnet

### DIFF
--- a/pybatfish/datamodel/flow.py
+++ b/pybatfish/datamodel/flow.py
@@ -712,7 +712,7 @@ class MatchTcpFlags(DataModelElement):
 
 def _get_color_for_disposition(disposition):
     # type: (str) -> str
-    success_dispositions = {"ACCEPTED", "DELIVERED", "EXITS_NETWORK"}
+    success_dispositions = {"ACCEPTED", "DELIVERED_TO_SUBNET", "EXITS_NETWORK"}
     if disposition in success_dispositions:
         return "#019612"
     else:


### PR DESCRIPTION
We had incorrect name in the set of success dispositions