### PR TITLE
Update asserts module with new ACL assertions

### DIFF
--- a/docs/source/asserts.rst
+++ b/docs/source/asserts.rst
@@ -1,0 +1,5 @@
+Assertion helpers
+=================
+
+.. automodule:: pybatfish.client.asserts
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ for building and running Batfish service.
    quickstart.rst
    questions.rst
    datamodel.rst
+   asserts.rst
    api.rst
 
 Indices and tables

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
                       'requests-toolbelt',
                       'simplejson',
                       'six',
-                      ] + (['enum34', 'typing'] if PY2 else []),
+                      ] + (['enum34', 'mock', 'typing'] if PY2 else []),
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/client/test_assert.py
+++ b/tests/client/test_assert.py
@@ -11,12 +11,23 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
 import pytest
+import six
+from pandas import DataFrame
 
-from pybatfish.client.asserts import _raise_common
+from pybatfish.client.asserts import (_raise_common, assert_acl_denies,
+                                      assert_acl_permits)
+from pybatfish.datamodel import HeaderConstraints
+from pybatfish.datamodel.answer import TableAnswer
 from pybatfish.exception import (BatfishAssertException,
                                  BatfishAssertWarning)
+from pybatfish.question import bfq
+from pybatfish.question.question import QuestionBase
+
+if six.PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 
 def test_raise_common_default():
@@ -32,3 +43,65 @@ def test_raise_common_default():
 def test_raise_common_warn():
     with pytest.warns(BatfishAssertWarning):
         _raise_common("foobar", True)
+
+
+class MockTableAnswer(TableAnswer):
+    def __init__(self, frame_to_use=DataFrame()):
+        self._frame = frame_to_use
+
+    def frame(self):
+        return self._frame
+
+
+class MockQuestion(QuestionBase):
+    def __init__(self, answer=None):
+        self._answer = answer if answer is not None else MockTableAnswer()
+
+    def answer(self, **kwargs):
+        return self._answer
+
+
+def test_acl_permits():
+    headers = HeaderConstraints(srcIps='1.1.1.1')
+    with patch.object(bfq, 'searchFilters', create=True) as mock_search_filters:
+        # Test success
+        mock_search_filters.return_value = MockQuestion()
+        assert_acl_permits('filter', headers)
+        mock_search_filters.assert_called_with(filters='filter',
+                                               headers=headers,
+                                               action='deny')
+        # Test failure; also test that startLocation is passed through
+        mock_df = DataFrame.from_records([{'Flow': 'found', 'More': 'data'}])
+        mock_search_filters.return_value = MockQuestion(
+            MockTableAnswer(mock_df))
+        with pytest.raises(BatfishAssertException) as excinfo:
+            assert_acl_permits('filter', headers, startLocation='Ethernet1')
+            # Ensure found answer is printed
+            assert str(mock_df) in str(excinfo)
+            mock_search_filters.assert_called_with(filters='filter',
+                                                   headers=headers,
+                                                   startLocation='Ethernet1',
+                                                   action='deny')
+
+
+def test_acl_denies():
+    headers = HeaderConstraints(srcIps='1.1.1.1')
+    with patch.object(bfq, 'searchFilters', create=True) as mock_search_filters:
+        # Test success
+        mock_search_filters.return_value = MockQuestion()
+        assert_acl_denies('filter', headers)
+        mock_search_filters.assert_called_with(filters='filter',
+                                               headers=headers,
+                                               action='permit')
+        # Test failure; also test that startLocation is passed through
+        mock_df = DataFrame.from_records([{'Flow': 'found', 'More': 'data'}])
+        mock_search_filters.return_value = MockQuestion(
+            MockTableAnswer(mock_df))
+        with pytest.raises(BatfishAssertException) as excinfo:
+            assert_acl_permits('filter', headers)
+            # Ensure found answer is printed
+            assert str(mock_df) in str(excinfo)
+            mock_search_filters.assert_called_with(filters='filter',
+                                                   headers=headers,
+                                                   startLocation='Ethernet1',
+                                                   action='permit')

--- a/tests/integration/test_answer_funcs.py
+++ b/tests/integration/test_answer_funcs.py
@@ -53,7 +53,8 @@ def traceroute_network():
     except Exception:
         pass
     bf_set_network(TEST_NETWORK)
-    yield bf_init_snapshot(join(_this_dir, "tracert_snapshot"), name="snapshot_tracert")
+    yield bf_init_snapshot(join(_this_dir, "tracert_snapshot"),
+                           name="snapshot_tracert")
     bf_delete_network(TEST_NETWORK)
 
 
@@ -75,7 +76,8 @@ def test_init_analysis(network):
 
 def test_answer_traceroute(traceroute_network):
     bf_session.additionalArgs = {'debugflags': 'traceroute'}
-    answer = bfq.traceroute(startLocation="hop1", headers=HeaderConstraints(dstIps="1.0.0.2")).answer().frame()
+    answer = bfq.traceroute(startLocation="hop1", headers=HeaderConstraints(
+        dstIps="1.0.0.2")).answer().frame()
     list_traces = answer.iloc[0]['Traces']
     assert len(list_traces) == 1
     trace = list_traces[0]


### PR DESCRIPTION
* Assertions for ACL permit/deny actions for headerspace
* Plumb though assertion module to the docs

Thoughts on whether we call it ACL or filter?