### PR TITLE
setup.py and testing improvements

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -12,7 +12,7 @@ fi
 
 if [ -n "$TRAVIS_BUILD_DIR" ]; then
    # Build and install pybatfish
-   pip install -e .[dev,test]
+   pip install -e .[dev]
    export QUESTIONS_DIR=questions
 else
    export QUESTIONS_DIR=../batfish/questions
@@ -55,9 +55,9 @@ python setup.py build_sphinx
 #### Running integration tests (require batfish)
 echo -e "\n  ..... Running python integration with batfish"
 retcode=0
-py.test tests/integration || retcode=$?
+pytest tests/integration || retcode=$?
 
 echo -e "\n  ..... Running doctests"
-py.test docs pybatfish --doctest-glob='docs/source/*.rst' --doctest-modules
+pytest docs pybatfish --doctest-glob='docs/source/*.rst' --doctest-modules
 
 exit ${retcode}

--- a/README.dev.md
+++ b/README.dev.md
@@ -6,7 +6,7 @@
 For this purpose, you will likely want [virtualenv](https://virtualenv.pypa.io/en/stable/) or [Anaconda](https://www.anaconda.com/download/)
 
 #### Installing in development mode 
-Run `pip install -e .[dev,test]`
+Run `pip install -e .[dev]`
 
 This installs all the development and test dependencies.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ deprecated
 jupyter
 nbconvert
 nbformat
-netconan
+netconan>=0.9.2
 pandas>=0.24.0,<0.25.0
 python-dateutil
 requests

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     install_requires=['attrs>=18.1.0',
                       'deepdiff',
                       'deprecated',
-                      'netconan',
+                      'netconan>=0.9.2',
                       'pandas>=0.24.0,<0.25.0',
                       'python-dateutil',
                       'requests',
@@ -115,26 +115,28 @@ setup(
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:
-    # $ pip install -e .[dev,test]
+    # $ pip install -e .[dev]
     extras_require={
         'dev': ['check-manifest',
+                'coverage',
                 'flake8',
                 'flake8-docstrings',
                 'flake8-import-order',
                 'jupyter',
                 'nbformat',
                 'nbconvert',
+                'pytest>=4.2.0,<5.0.0',
                 'pytz',
-                'sphinx',
+                'requests_mock',
+                'responses',
+                'sphinx>=1.8.0',
                 'sphinx_rtd_theme',
                 ] + \
                (['mypy'] if not PY2 else []),
-        'test': ['coverage', 'pytz', 'responses'],
     },
 
     # List pytest requirements for running unit tests
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'requests_mock'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
* No need to split dev and test extras. All devs should test
* Update dev readme
* Put pytest as a proper dev dependency: `tests_require` does **not** install the
dependencies, but .travis/build assumes pytest is installed
* Travis scripts: use newer `pytest` instead of `py.test`
* Pin more dependencies: sphinx, netconan

cc: @sfraint 