### PR TITLE
pybatfish: add extra_args to WorkItem executors

### DIFF
--- a/pybatfish/client/diagnostics.py
+++ b/pybatfish/client/diagnostics.py
@@ -99,7 +99,11 @@ def _upload_diagnostics(bucket=_S3_BUCKET, region=_S3_REGION, dry_run=True,
         for q in questions:
             instance_name = q.get_name()
             try:
-                ans = q.answer()  # type: Answer
+                ans = q.answer()
+                if not isinstance(ans, Answer):
+                    raise BatfishException(
+                        "question.answer() did not return an Answer: {}".format(
+                            ans))
                 content = json.dumps(ans.dict(), indent=4, sort_keys=True)
             except BatfishException as e:
                 content = "Failed to answer {}: {}".format(instance_name, e)
@@ -179,7 +183,12 @@ def _get_snapshot_parse_status():
     """
     parse_status = {}  # type: Dict[str, str]
     try:
-        answer = _INIT_INFO_QUESTION.answer()  # type: Answer
+        answer = _INIT_INFO_QUESTION.answer()
+        if not isinstance(answer, Answer):
+            raise BatfishException(
+                "question.answer() did not return an Answer: {}".format(
+                    answer))
+
         if 'answerElements' not in answer:
             raise BatfishException('Invalid answer format for init info')
         answer_elements = answer['answerElements']

--- a/pybatfish/client/diagnostics.py
+++ b/pybatfish/client/diagnostics.py
@@ -25,6 +25,7 @@ import requests
 from netconan import netconan
 from requests import HTTPError
 
+from pybatfish.datamodel.answer import Answer  # noqa: F401
 from pybatfish.exception import BatfishException
 from pybatfish.question.question import QuestionBase
 
@@ -98,8 +99,8 @@ def _upload_diagnostics(bucket=_S3_BUCKET, region=_S3_REGION, dry_run=True,
         for q in questions:
             instance_name = q.get_name()
             try:
-                content = json.dumps(q.answer().dict(), indent=4,
-                                     sort_keys=True)
+                ans = q.answer()  # type: Answer
+                content = json.dumps(ans.dict(), indent=4, sort_keys=True)
             except BatfishException as e:
                 content = "Failed to answer {}: {}".format(instance_name, e)
                 bf_logger.warning(content)
@@ -178,7 +179,7 @@ def _get_snapshot_parse_status():
     """
     parse_status = {}  # type: Dict[str, str]
     try:
-        answer = _INIT_INFO_QUESTION.answer()
+        answer = _INIT_INFO_QUESTION.answer()  # type: Answer
         if 'answerElements' not in answer:
             raise BatfishException('Invalid answer format for init info')
         answer_elements = answer['answerElements']

--- a/pybatfish/client/internal.py
+++ b/pybatfish/client/internal.py
@@ -15,12 +15,13 @@
 """Contains internal functions for interacting with the Batfish service."""
 
 import json
-from typing import Dict, Optional, Union  # noqa: F401
+from typing import Any, Dict, Optional, Union  # noqa: F401
 
 import six
 
 from pybatfish.client.consts import CoordConsts
 from pybatfish.datamodel import answer
+from pybatfish.datamodel.answer import Answer  # noqa: F401
 from pybatfish.util import (get_uuid)
 from . import resthelper, workhelper
 from .options import Options
@@ -28,8 +29,8 @@ from .workhelper import _get_data_get_question_templates
 
 
 def _bf_answer_obj(question_str, parameters_str, question_name,
-                   background, snapshot, reference_snapshot):
-    # type: (str, str, str, bool, str, Optional[str]) -> Union[str, Dict]
+                   background, snapshot, reference_snapshot, extra_args):
+    # type: (str, str, str, bool, str, Optional[str], Optional[Dict[str, Any]]) -> Union[Answer, str]
     from pybatfish.client.commands import bf_session
 
     json.loads(parameters_str)  # a syntactic check for parametersStr
@@ -46,7 +47,7 @@ def _bf_answer_obj(question_str, parameters_str, question_name,
     # Answer the question
     work_item = workhelper.get_workitem_answer(bf_session, question_name,
                                                snapshot, reference_snapshot)
-    workhelper.execute(work_item, bf_session, background)
+    workhelper.execute(work_item, bf_session, background, extra_args)
 
     if background:
         return work_item.id
@@ -69,7 +70,6 @@ def _bf_answer_obj(question_str, parameters_str, question_name,
 def _bf_get_question_templates():
     from pybatfish.client.commands import bf_session
     jsonData = _get_data_get_question_templates(bf_session)
-    jsonResponse = resthelper.get_json_response(bf_session,
-                                                CoordConsts.SVC_RSC_GET_QUESTION_TEMPLATES,
-                                                jsonData)
+    jsonResponse = resthelper.get_json_response(
+        bf_session, CoordConsts.SVC_RSC_GET_QUESTION_TEMPLATES, jsonData)
     return jsonResponse[CoordConsts.SVC_KEY_QUESTION_LIST]

--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -69,8 +69,8 @@ def _print_timestamp(timestamp):
     return timestamp.astimezone(tzlocal()).strftime("%c %Z")
 
 
-def execute(work_item, session, background=False):
-    # type: (WorkItem, Session, bool) -> Dict[str, Any]
+def execute(work_item, session, background=False, extra_args=None):
+    # type: (WorkItem, Session, bool, Optional[Dict[str, Any]]) -> Dict[str, Any]
     """Submit a work item to Batfish.
 
     :param work_item: work to submit
@@ -80,11 +80,16 @@ def execute(work_item, session, background=False):
     :param background: Whether to background the job. If `True`,
         this function only returns the result of submitting the job.
     :type background: bool
+    :param extra_args: extra arguments to be passed to Batfish. See bf_session.additionalArgs.
+    :type extra_args: dict
 
     :return: If `background=True`, a dict containing a single key 'result' with
     a string description of the result. If `background=False`, a dict containing
     a single key 'status' with a string describing work status.
     """
+    if extra_args is not None:
+        work_item.requestParams.update(extra_args)
+
     snapshot = work_item.requestParams.get(BfConsts.ARG_TESTRIG)
     if snapshot is None:
         raise ValueError('Work item {} does not include a snapshot name'.format(

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -34,6 +34,7 @@ from pybatfish.client.internal import (_bf_answer_obj,
                                        _bf_get_question_templates)
 from pybatfish.datamodel import Assertion, AssertionType, \
     VariableType  # noqa: F401
+from pybatfish.datamodel.answer import Answer  # noqa: F401
 from pybatfish.exception import QuestionValidationException
 from pybatfish.question import bfq
 from pybatfish.util import BfJsonEncoder, get_uuid, validate_question_name
@@ -141,7 +142,8 @@ class QuestionBase(object):
         self._dict = deepcopy(dictionary)
 
     def answer(self, snapshot=None, reference_snapshot=None,
-               include_one_table_keys=None, background=False):
+               include_one_table_keys=None, background=False, extra_args=None):
+        # type: (Optional[str], Optional[str], Optional[bool], bool, Optional[Dict[str, Any]]) -> Union[str, Answer]
         """
         Ask and return the answer for this question.
 
@@ -156,13 +158,15 @@ class QuestionBase(object):
         :type include_one_table_keys: bool
         :param background: run this question in background, return immediately
         :type background: bool
+        :param extra_args: extra arguments to be passed to the parse command. See bf_session.additionalArgs.
+        :type extra_args: dict
         :rtype: :py:class:`~pybatfish.datamodel.answer.base.Answer` or
             :py:class:`~pybatfish.datamodel.answer.table.TableAnswer`
 
         :raises QuestionValidationException: if the question is malformed
         """
         from pybatfish.client.commands import bf_session
-        snapshot = bf_session.get_snapshot(snapshot)
+        real_snapshot = bf_session.get_snapshot(snapshot)
         if reference_snapshot is None and self.get_differential():
             raise ValueError(
                 "reference_snapshot argument is required to answer a differential question")
@@ -173,8 +177,9 @@ class QuestionBase(object):
                               parameters_str="{}",
                               question_name=self.get_name(),
                               background=background,
-                              snapshot=snapshot,
-                              reference_snapshot=reference_snapshot)
+                              snapshot=real_snapshot,
+                              reference_snapshot=reference_snapshot,
+                              extra_args=extra_args)
 
     def dict(self):
         """Return the dictionary representing this question."""

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -16,7 +16,7 @@
 import pytest
 
 from pybatfish.client.commands import (bf_fork_snapshot, bf_init_snapshot,
-                                       bf_set_network, bf_session)
+                                       bf_session, bf_set_network)
 
 
 def test_network_validation():

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -16,7 +16,7 @@
 import pytest
 
 from pybatfish.client.commands import (bf_fork_snapshot, bf_init_snapshot,
-                                       bf_set_network)
+                                       bf_set_network, bf_session)
 
 
 def test_network_validation():
@@ -25,6 +25,7 @@ def test_network_validation():
 
 
 def test_snapshot_validation():
+    bf_session.network = 'testnet'
     with pytest.raises(ValueError):
         bf_init_snapshot("x", name="foo/bar")
 

--- a/tests/client/test_workhelper.py
+++ b/tests/client/test_workhelper.py
@@ -17,13 +17,17 @@ import json
 import logging
 
 import pytest
+import six
 from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzlocal
 from pytz import UTC
 
+from client.consts import BfConsts
+from pybatfish.client import resthelper
 from pybatfish.client.session import Session
 from pybatfish.client.workhelper import _format_elapsed_time, _parse_timestamp, \
-    _print_timestamp, _print_work_status
+    _print_timestamp, _print_work_status, execute
+from pybatfish.client.workitem import WorkItem
 
 
 @pytest.fixture
@@ -31,6 +35,49 @@ def logger(caplog):
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
     return logger
+
+
+if six.PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
+
+
+def __execute_and_return_request_params(work_item, session, extra_args=None):
+    work_item.requestParams[BfConsts.ARG_TESTRIG] = 'snapshot'
+    with patch.object(resthelper,
+                      'get_json_response') as mock_get_json_response:
+        execute(work_item, session, True, extra_args)
+    args, kwargs = mock_get_json_response.call_args
+    witem = json.loads(args[2]['workitem'])
+    return witem['requestParams']
+
+
+def test_execute_request_params(logger):
+    session = Session(logger)
+
+    # Unmodified work item
+    work_item = WorkItem(session)
+    witem = __execute_and_return_request_params(work_item, session)
+    assert 'TESTARG' not in witem
+
+    session.additionalArgs['TESTARG'] = 'addl'
+
+    # Work item with additional args
+    work_item = WorkItem(session)
+    witem = __execute_and_return_request_params(work_item, session)
+    assert witem.get('TESTARG') == 'addl'
+
+    # Work item with additional args and extra args
+    work_item = WorkItem(session)
+    witem = __execute_and_return_request_params(
+        work_item, session, extra_args={'TESTARG': 'extra'})
+    assert witem.get('TESTARG') == 'extra'
+
+    # Confirm additional args not messed up
+    work_item = WorkItem(session)
+    witem = __execute_and_return_request_params(work_item, session)
+    assert witem.get('TESTARG') == 'addl'
 
 
 def test_format_elapsed_time():

--- a/tests/client/test_workhelper.py
+++ b/tests/client/test_workhelper.py
@@ -22,8 +22,8 @@ from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzlocal
 from pytz import UTC
 
-from client.consts import BfConsts
 from pybatfish.client import resthelper
+from pybatfish.client.consts import BfConsts
 from pybatfish.client.session import Session
 from pybatfish.client.workhelper import _format_elapsed_time, _parse_timestamp, \
     _print_timestamp, _print_work_status, execute


### PR DESCRIPTION
These are plumbed through to `WorkItem.requestParams`,
just like `bf_session.additionalArgs`. However, per-call
arguments are temporary and take precedence over
the session args.