### PR TITLE
workhelper: ramp up sleeping to 1s

### DIFF
--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -114,9 +114,11 @@ def execute(work_item, session, background=False, extra_args=None):
         status = WorkStatusCode(answer[CoordConsts.SVC_KEY_WORKSTATUS])
         task_details = answer[CoordConsts.SVC_KEY_TASKSTATUS]
 
+        cur_sleep = 0.1  # seconds
         while not WorkStatusCode.is_terminated(status):
             print_work_status(session, status, task_details)
-            time.sleep(1)
+            time.sleep(cur_sleep)
+            cur_sleep = min(1.0, cur_sleep * 1.5)
             answer = get_work_status(work_item.id, session)
             status = WorkStatusCode(answer[CoordConsts.SVC_KEY_WORKSTATUS])
             task_details = answer[CoordConsts.SVC_KEY_TASKSTATUS]


### PR DESCRIPTION
This will terminate short work items much more quickly, but will also check status (and print) up to 4 more times than before where we always slept every second:

* 0s [happened before after 0s cumulative sleep]
* 0.1s
* 0.25s
* 0.48s
* 0.81s
* 1.32s  [happened before after 1s cumulative sleep]
* 2.08s  [happened before after 2s cumulative sleep]
* 3.08s  [happened before after 3s cumulative sleep]
* ...