### PR TITLE
Update Session constructor params and vars

### DIFF
--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -265,7 +265,7 @@ def bf_fork_snapshot(base_name, name=None, overwrite=False,
     :type restore_nodes: list[str]
     :param add_files: path to zip file or directory containing files to add
     :type add_files: str
-    :param extra_args: extra arguments to be passed to the parse command. See bf_session.additionalArgs.
+    :param extra_args: extra arguments to be passed to the parse command. See bf_session.additional_args.
     :type extra_args: dict
     :return: name of initialized snapshot, JSON dictionary of task status if
         background=True, or None if the call fails
@@ -321,7 +321,8 @@ def bf_generate_dataplane(snapshot=None, extra_args=None):
     snapshot = bf_session.get_snapshot(snapshot)
 
     work_item = workhelper.get_workitem_generate_dataplane(bf_session, snapshot)
-    answer_dict = workhelper.execute(work_item, bf_session, extra_args=extra_args)
+    answer_dict = workhelper.execute(work_item, bf_session,
+                                     extra_args=extra_args)
     return str(answer_dict["status"].value)
 
 
@@ -452,7 +453,8 @@ def bf_init_analysis(analysisName, questionDirectory):
     return _bf_init_or_add_analysis(analysisName, questionDirectory, True)
 
 
-def bf_init_snapshot(upload, name=None, overwrite=False, background=False, extra_args=None):
+def bf_init_snapshot(upload, name=None, overwrite=False, background=False,
+                     extra_args=None):
     # type: (str, Optional[str], bool, bool, Optional[Dict[str, Any]]) -> Union[str, Dict[str, str]]
     """Initialize a new snapshot.
 
@@ -465,7 +467,7 @@ def bf_init_snapshot(upload, name=None, overwrite=False, background=False, extra
     :type overwrite: bool
     :param background: whether or not to run the task in the background
     :type background: bool
-    :param extra_args: extra arguments to be passed to the parse command. See bf_session.additionalArgs.
+    :param extra_args: extra arguments to be passed to the parse command. See bf_session.additional_args.
     :type extra_args: dict
     :return: name of initialized snapshot, or JSON dictionary of task status if background=True
     :rtype: Union[str, Dict]
@@ -508,7 +510,7 @@ def _parse_snapshot(name, background, extra_args):
     :type name: str
     :param background: whether or not to run the task in the background
     :type background: bool
-    :param extra_args: extra arguments to be passed to the parse command. See bf_session.additionalArgs.
+    :param extra_args: extra arguments to be passed to the parse command. See bf_session.additional_args.
     :type extra_args: dict
     :return: name of initialized snapshot, or JSON dictionary of task status if background=True
     :rtype: Union[str, Dict]
@@ -518,7 +520,7 @@ def _parse_snapshot(name, background, extra_args):
                                      background=background,
                                      extra_args=extra_args)
     if background:
-        bf_session.baseSnapshot = name
+        bf_session.snapshot = name
         return answer_dict
 
     status = WorkStatusCode(answer_dict["status"])
@@ -529,13 +531,13 @@ def _parse_snapshot(name, background, extra_args):
             'Initializing snapshot {ss} failed with status {status}\n{log}'.format(
                 ss=name, status=status, log=init_log))
     else:
-        bf_session.baseSnapshot = name
+        bf_session.snapshot = name
         bf_logger.info("Default snapshot is now set to %s",
-                       bf_session.baseSnapshot)
+                       bf_session.snapshot)
         if bf_session.enable_diagnostics:
             _warn_on_snapshot_failure()
 
-        return bf_session.baseSnapshot
+        return bf_session.snapshot
 
 
 def bf_kill_work(wItemId):
@@ -655,7 +657,8 @@ def bf_run_analysis(name, snapshot, reference_snapshot=None, extra_args=None):
     # type: (str, str, Optional[str], Optional[Dict[str, Any]]) -> Any
     work_item = workhelper.get_workitem_run_analysis(
         bf_session, name, snapshot, reference_snapshot)
-    work_answer = workhelper.execute(work_item, bf_session, extra_args=extra_args)
+    work_answer = workhelper.execute(work_item, bf_session,
+                                     extra_args=extra_args)
     if work_answer["status"] != WorkStatusCode.TERMINATEDNORMALLY:
         raise BatfishException("Failed to run analysis")
 
@@ -727,7 +730,7 @@ def bf_set_snapshot(name=None, index=None):
             raise IndexError(
                 "Server has only {} snapshots: {}".format(
                     len(snapshots), snapshots))
-        bf_session.baseSnapshot = str(snapshots[index])
+        bf_session.snapshot = str(snapshots[index])
 
     # Name specified, make sure it exists.
     else:
@@ -736,10 +739,10 @@ def bf_set_snapshot(name=None, index=None):
             raise ValueError(
                 'No snapshot named ''{}'' was found in network ''{}'': {}'.format(
                     name, bf_session.network, snapshots))
-        bf_session.baseSnapshot = name
+        bf_session.snapshot = name
 
-    bf_logger.info("Default snapshot is now set to %s", bf_session.baseSnapshot)
-    return bf_session.baseSnapshot
+    bf_logger.info("Default snapshot is now set to %s", bf_session.snapshot)
+    return bf_session.snapshot
 
 
 def bf_upload_diagnostics(dry_run=True, netconan_config=None):

--- a/pybatfish/client/resthelper.py
+++ b/pybatfish/client/resthelper.py
@@ -50,7 +50,7 @@ _requests_session.mount("http", HTTPAdapter(
 
 def get_answer(session, snapshot, question_name, reference_snapshot=None):
     # type: (Session, str, str, Optional[str]) -> bytes
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
                  CoordConsts.SVC_KEY_SNAPSHOT_NAME: snapshot,
                  CoordConsts.SVC_KEY_QUESTION_NAME: question_name,
@@ -107,7 +107,7 @@ def _make_request(session, resource, json_data=None, stream=False,
     url = session.get_url(resource)
     if use_http_get:
         response = _requests_session.get(
-            url, verify=session.verifySslCerts, stream=stream)
+            url, verify=session.verify_ssl_certs, stream=stream)
     else:
         if json_data is None:
             json_data = {}
@@ -115,7 +115,7 @@ def _make_request(session, resource, json_data=None, stream=False,
         multipart_data = MultipartEncoder(json_data)
         headers = {'Content-Type': multipart_data.content_type}
         response = _requests_session.post(
-            url, data=multipart_data, verify=session.verifySslCerts,
+            url, data=multipart_data, verify=session.verify_ssl_certs,
             stream=stream, headers=headers)
     response.raise_for_status()
     return response

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -274,7 +274,8 @@ def get_snapshot_inferred_node_roles(session, snapshot=None):
     return _get_dict(session, url_tail)
 
 
-def get_snapshot_inferred_node_role_dimension(session, dimension, snapshot=None):
+def get_snapshot_inferred_node_role_dimension(session, dimension,
+                                              snapshot=None):
     # type: (Session, str, Optional[str]) -> Dict
     """Gets the suggested definition and hypothetical assignments of node roles for the given inferred dimension for the active network and snapshot."""
     if not session.network:
@@ -428,13 +429,13 @@ def _delete(session, url_tail, params=None):
     :raises SSLError if SSL connection failed
     :raises ConnectionError if the coordinator is not available
     """
-    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.apiKey,
+    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.api_key,
                CoordConstsV2.HTTP_HEADER_BATFISH_VERSION: pybatfish.__version__}
     url = session.get_base_url2() + url_tail
     response = requests.delete(url,
                                headers=headers,
                                params=params,
-                               verify=session.verifySslCerts)
+                               verify=session.verify_ssl_certs)
     _check_response_status(response)
 
 
@@ -445,14 +446,14 @@ def _get(session, url_tail, params, stream=False):
     :raises SSLError if SSL connection failed
     :raises ConnectionError if the coordinator is not available
     """
-    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.apiKey,
+    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.api_key,
                CoordConstsV2.HTTP_HEADER_BATFISH_VERSION: pybatfish.__version__}
     url = session.get_base_url2() + url_tail
     response = requests.get(url,
                             headers=headers,
                             params=params,
                             stream=stream,
-                            verify=session.verifySslCerts)
+                            verify=session.verify_ssl_certs)
     _check_response_status(response)
     return response
 
@@ -498,14 +499,14 @@ def _post(session, url_tail, obj, params=None):
     :raises SSLError if SSL connection failed
     :raises ConnectionError if the coordinator is not available
     """
-    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.apiKey,
+    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.api_key,
                CoordConstsV2.HTTP_HEADER_BATFISH_VERSION: pybatfish.__version__}
     url = session.get_base_url2() + url_tail
     response = requests.post(url,
                              json=_encoder.default(obj),
                              headers=headers,
                              params=params,
-                             verify=session.verifySslCerts)
+                             verify=session.verify_ssl_certs)
     _check_response_status(response)
     return None
 
@@ -517,7 +518,7 @@ def _put(session, url_tail, params=None, json=None, stream=None):
     :raises SSLError if SSL connection failed
     :raises ConnectionError if the coordinator is not available
     """
-    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.apiKey,
+    headers = {CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY: session.api_key,
                CoordConstsV2.HTTP_HEADER_BATFISH_VERSION: pybatfish.__version__}
     if stream:
         headers['Content-Type'] = 'application/octet-stream'
@@ -526,7 +527,7 @@ def _put(session, url_tail, params=None, json=None, stream=None):
                             json=json,
                             data=stream,
                             headers=headers,
-                            verify=session.verifySslCerts,
+                            verify=session.verify_ssl_certs,
                             params=params)
     _check_response_status(response)
     return None

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -64,73 +64,83 @@ class Session(object):
         self.enable_diagnostics = True  # type: bool
 
     # Support old property names
-    @property
-    @deprecated(reason="Use additional_args")
+    @property  # type: ignore
+    @deprecated(reason="Use the new additional_args field instead")
     def additionalArgs(self):
         return self.additional_args
 
-    @additionalArgs.setter
-    @deprecated(reason="Use additional_args")
+    @additionalArgs.setter  # type: ignore
+    @deprecated(reason="Use the new additional_args field instead")
     def additionalArgs(self, val):
         self.additional_args = val
 
-    @property
-    @deprecated(reason="Use api_key")
+    @property  # type: ignore
+    @deprecated(reason="Use the new api_key field instead")
     def apiKey(self):
         return self.api_key
 
-    @apiKey.setter
-    @deprecated(reason="Use api_key")
+    @apiKey.setter  # type: ignore
+    @deprecated(reason="Use the new api_key field instead")
     def apiKey(self, val):
         self.api_key = val
 
-    @property
-    @deprecated(reason="Use snapshot")
+    @property  # type: ignore
+    @deprecated(reason="Use the new snapshot field instead")
     def baseSnapshot(self):
         return self.snapshot
 
-    @baseSnapshot.setter
-    @deprecated(reason="Use snapshot")
+    @baseSnapshot.setter  # type: ignore
+    @deprecated(reason="Use the new snapshot field instead")
     def baseSnapshot(self, val):
         self.snapshot = val
 
-    @property
-    @deprecated(reason="Use port_v1")
+    @property  # type: ignore
+    @deprecated(reason="Use the new host field instead")
+    def coordinatorHost(self):
+        return self.host
+
+    @coordinatorHost.setter  # type: ignore
+    @deprecated(reason="Use the new host field instead")
+    def coordinatorHost(self, val):
+        self.host = val
+
+    @property  # type: ignore
+    @deprecated(reason="Use the new port_v1 field instead")
     def coordinatorPort(self):
         return self.port_v1
 
-    @coordinatorPort.setter
-    @deprecated(reason="Use port_v1")
+    @coordinatorPort.setter  # type: ignore
+    @deprecated(reason="Use the new port_v1 field instead")
     def coordinatorPort(self, val):
         self.port_v1 = val
 
-    @property
-    @deprecated(reason="Use port_v2")
+    @property  # type: ignore
+    @deprecated(reason="Use the new port_v2 field instead")
     def coordinatorPort2(self):
         return self.port_v2
 
-    @coordinatorPort2.setter
-    @deprecated(reason="Use port_v2")
+    @coordinatorPort2.setter  # type: ignore
+    @deprecated(reason="Use the new port_v2 field instead")
     def coordinatorPort2(self, val):
         self.port_v2 = val
 
-    @property
-    @deprecated(reason="Use ssl")
+    @property  # type: ignore
+    @deprecated(reason="Use the new ssl field instead")
     def useSsl(self):
         return self.ssl
 
-    @useSsl.setter
-    @deprecated(reason="Use ssl")
+    @useSsl.setter  # type: ignore
+    @deprecated(reason="Use the new ssl field instead")
     def useSsl(self, val):
         self.ssl = val
 
-    @property
-    @deprecated(reason="Use verify_ssl_certs")
+    @property  # type: ignore
+    @deprecated(reason="Use the new verify_ssl_certs field instead")
     def verifySslCerts(self):
         return self.verify_ssl_certs
 
-    @verifySslCerts.setter
-    @deprecated(reason="Use verify_ssl_certs")
+    @verifySslCerts.setter  # type: ignore
+    @deprecated(reason="Use the new verify_ssl_certs field instead")
     def verifySslCerts(self, val):
         self.verify_ssl_certs = val
 

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import, print_function
 
 from logging import Logger  # noqa: F401
-from typing import Dict, Optional  # noqa: F401
+from typing import Dict, Optional, Text  # noqa: F401
 
 from deprecated import deprecated
 
@@ -39,9 +39,9 @@ class Session(object):
                  port_v2=Options.coordinator_work_v2_port,
                  ssl=Options.use_ssl,
                  verify_ssl_certs=Options.verify_ssl_certs):
-        # type: (Logger, str, int, int, bool, bool) -> None
+        # type: (Logger, Text, int, int, bool, bool) -> None
         # Coordinator args
-        self.host = host  # type: str
+        self.host = host  # type: Text
         self.port_v1 = port_v1  # type: int
         self._base_uri_v1 = CoordConsts.SVC_CFG_WORK_MGR  # type: str
         self.port_v2 = port_v2  # type: int

--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -80,7 +80,7 @@ def execute(work_item, session, background=False, extra_args=None):
     :param background: Whether to background the job. If `True`,
         this function only returns the result of submitting the job.
     :type background: bool
-    :param extra_args: extra arguments to be passed to Batfish. See bf_session.additionalArgs.
+    :param extra_args: extra arguments to be passed to Batfish. See bf_session.additional_args.
     :type extra_args: dict
 
     :return: If `background=True`, a dict containing a single key 'result' with
@@ -97,7 +97,7 @@ def execute(work_item, session, background=False, extra_args=None):
 
     json_data = {
         CoordConsts.SVC_KEY_WORKITEM: work_item.to_json(),
-        CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+        CoordConsts.SVC_KEY_API_KEY: session.api_key,
     }
 
     # Submit the work item
@@ -180,7 +180,7 @@ def get_data_upload_question(session, question_name, question_json,
                              parameters_json):
     # type: (Session, str, str, str) -> Dict
     """Create the form parameters needed to upload the given question."""
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
                  CoordConsts.SVC_KEY_QUESTION_NAME: question_name,
                  CoordConsts.SVC_KEY_FILE: ('question', question_json),
@@ -189,9 +189,9 @@ def get_data_upload_question(session, question_name, question_json,
 
 
 def get_data_auto_complete(session, completion_type, query, max_suggestions):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
-                 CoordConsts.SVC_KEY_SNAPSHOT_NAME: session.baseSnapshot,
+                 CoordConsts.SVC_KEY_SNAPSHOT_NAME: session.snapshot,
                  CoordConsts.SVC_KEY_COMPLETION_TYPE: completion_type,
                  CoordConsts.SVC_KEY_QUERY: query}
     if max_suggestions:
@@ -201,7 +201,7 @@ def get_data_auto_complete(session, completion_type, query, max_suggestions):
 
 def get_data_configure_analysis(session, new_analysis, analysis_name,
                                 add_questions_filename, del_questions_str):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network}
     if new_analysis:
         json_data[CoordConsts.SVC_KEY_NEW_ANALYSIS] = "new"
@@ -218,7 +218,7 @@ def get_data_configure_analysis(session, new_analysis, analysis_name,
 
 def get_data_configure_question_template(session, in_question, exceptions,
                                          assertion):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_QUESTION: in_question}
     if exceptions:
         json_data[CoordConsts.SVC_KEY_EXCEPTIONS] = json.dumps(exceptions)
@@ -229,20 +229,20 @@ def get_data_configure_question_template(session, in_question, exceptions,
 
 
 def get_data_delete_analysis(session, analysis_name):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
                  CoordConsts.SVC_KEY_ANALYSIS_NAME: analysis_name}
     return json_data
 
 
 def get_data_delete_network(session, name):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: name}
     return json_data
 
 
 def get_data_delete_snapshot(session, name):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
                  CoordConsts.SVC_KEY_SNAPSHOT_NAME: name}
     return json_data
@@ -252,7 +252,7 @@ def get_data_get_analysis_answers(session, analysis_name, snapshot,
                                   reference_snapshot=None):
     # type: (Session, str, str, Optional[str]) -> Dict
     json_data = {
-        CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+        CoordConsts.SVC_KEY_API_KEY: session.api_key,
         CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
         CoordConsts.SVC_KEY_SNAPSHOT_NAME: snapshot,
     }
@@ -264,7 +264,7 @@ def get_data_get_analysis_answers(session, analysis_name, snapshot,
 
 
 def _get_data_get_question_templates(session):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey}
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key}
     return json_data
 
 
@@ -272,7 +272,7 @@ def get_data_get_answer(session, question_name, snapshot,
                         reference_snapshot=None):
     # type: (Session, str, str, Optional[str]) -> Dict
     json_data = {
-        CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+        CoordConsts.SVC_KEY_API_KEY: session.api_key,
         CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
         CoordConsts.SVC_KEY_SNAPSHOT_NAME: snapshot,
         CoordConsts.SVC_KEY_QUESTION_NAME: question_name,
@@ -284,56 +284,56 @@ def get_data_get_answer(session, question_name, snapshot,
 
 
 def get_data_init_network(session, network_name):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: network_name}
     return json_data
 
 
 def get_data_kill_work(session, workId):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_WORKID: workId}
     return json_data
 
 
 def get_data_list_analyses(session):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network}
     return json_data
 
 
 def get_data_list_networks(session):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey}
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key}
     return json_data
 
 
 def get_data_list_incomplete_work(session):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network}
     return json_data
 
 
 def get_data_list_questions(session):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network}
     return json_data
 
 
 def get_data_list_snapshots(session, network):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey}
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key}
     if network is not None:
         json_data[CoordConsts.SVC_KEY_NETWORK_NAME] = network
     return json_data
 
 
 def get_data_list_testrigs(session, network):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey}
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key}
     if network is not None:
         json_data[CoordConsts.SVC_KEY_NETWORK_NAME] = network
     return json_data
 
 
 def get_data_sync_snapshots_sync_now(session, plugin_id, force):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
                  CoordConsts.SVC_KEY_PLUGIN_ID: plugin_id,
                  CoordConsts.SVC_KEY_FORCE: str(force)}
@@ -341,7 +341,7 @@ def get_data_sync_snapshots_sync_now(session, plugin_id, force):
 
 
 def get_data_sync_snapshots_update_settings(session, plugin_id, settings_dict):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
                  CoordConsts.SVC_KEY_PLUGIN_ID: plugin_id,
                  CoordConsts.SVC_KEY_SETTINGS: json.dumps(settings_dict)}
@@ -350,7 +350,7 @@ def get_data_sync_snapshots_update_settings(session, plugin_id, settings_dict):
 
 def get_data_upload_snapshot(session, snapshot, file_to_send):
     # type: (Session, str, str) -> Dict
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
                  CoordConsts.SVC_KEY_SNAPSHOT_NAME: snapshot,
                  CoordConsts.SVC_KEY_ZIPFILE: (
@@ -412,7 +412,7 @@ def get_workitem_run_analysis(session, analysis_name, snapshot,
 
 
 def get_work_status(w_item_id, session):
-    json_data = {CoordConsts.SVC_KEY_API_KEY: session.apiKey,
+    json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
                  CoordConsts.SVC_KEY_WORKID: w_item_id}
 
     answer = resthelper.get_json_response(session,

--- a/pybatfish/client/workitem.py
+++ b/pybatfish/client/workitem.py
@@ -33,7 +33,7 @@ class WorkItem(object):
         # type: (Session) -> None
         self.id = batfishutils.get_uuid()  # type: str
         self.network = session.network  # type: Optional[str]
-        self.requestParams = dict(session.additionalArgs)  # type: Dict
+        self.requestParams = dict(session.additional_args)  # type: Dict
 
     def to_json(self):
         # type: () -> str

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -158,7 +158,7 @@ class QuestionBase(object):
         :type include_one_table_keys: bool
         :param background: run this question in background, return immediately
         :type background: bool
-        :param extra_args: extra arguments to be passed to the parse command. See bf_session.additionalArgs.
+        :param extra_args: extra arguments to be passed to the parse command. See bf_session.additional_args.
         :type extra_args: dict
         :rtype: :py:class:`~pybatfish.datamodel.answer.base.Answer` or
             :py:class:`~pybatfish.datamodel.answer.table.TableAnswer`

--- a/tests/client/test_workhelper.py
+++ b/tests/client/test_workhelper.py
@@ -61,7 +61,7 @@ def test_execute_request_params(logger):
     witem = __execute_and_return_request_params(work_item, session)
     assert 'TESTARG' not in witem
 
-    session.additionalArgs['TESTARG'] = 'addl'
+    session.additional_args['TESTARG'] = 'addl'
 
     # Work item with additional args
     work_item = WorkItem(session)

--- a/tests/integration/test_answer_funcs.py
+++ b/tests/integration/test_answer_funcs.py
@@ -83,7 +83,7 @@ def test_init_analysis(network):
 
 
 def test_answer_traceroute(traceroute_network):
-    bf_session.additionalArgs = {'debugflags': 'traceroute'}
+    bf_session.additional_args = {'debugflags': 'traceroute'}
     answer = bfq.traceroute(startLocation="hop1", headers=HeaderConstraints(
         dstIps="1.0.0.2")).answer().frame()
     list_traces = answer.iloc[0]['Traces']


### PR DESCRIPTION
* Accept simple constructor params
* Update to use snake_case
* Support old param names for reverse compatibility, w/deprecated warning

New style:
```
> %run startup.py
> s = Session(bf_logger, host='example.com', ssl=True)
```
or
```
> %run startup.py
> bf_session.host = 'example.com'
> bf_session.ssl = True
```
But old style code still works:
```
> %run startup.py
> bf_session.coordinatorHost = 'example.com'
DeprecationWarning: Call to deprecated function (or staticmethod) coordinatorHost. (Use host)
> bf_session.useSsl = True
DeprecationWarning: Call to deprecated function (or staticmethod) useSsl. (Use ssl)
```