### PR TITLE
Initial migration of bf_cmd functionality into Session

### DIFF
--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -347,9 +347,7 @@ def bf_get_snapshot_inferred_node_roles():
 def bf_get_snapshot_inferred_node_role_dimension(dimension):
     # type: (str) -> NodeRoleDimension
     """Gets the suggested definition and hypothetical assignments of node roles for the given inferred dimension for the active network and snapshot."""
-    return NodeRoleDimension.from_dict(
-        restv2helper.get_snapshot_inferred_node_role_dimension(bf_session,
-                                                               dimension))
+    return bf_session.get_node_role_dimension(dimension, inferred=True)
 
 
 def bf_get_snapshot_node_roles():

--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -177,7 +177,6 @@ def bf_delete_issue_config(major, minor):
     restv2helper.delete_issue_config(bf_session, major, minor)
 
 
-@deprecated(reason="Use the new delete_network method in Session instead")
 def bf_delete_network(name):
     # type: (str) -> None
     """
@@ -189,23 +188,18 @@ def bf_delete_network(name):
     bf_session.delete_network(name)
 
 
-@deprecated(
-    reason="Use the new delete_node_role_dimension method in Session instead")
 def bf_delete_node_role_dimension(dimension):
     # type: (str) -> None
     """Deletes the definition of the given role dimension for the active network."""
     bf_session.delete_node_role_dimension(dimension)
 
 
-@deprecated(
-    reason="Use the new delete_reference_book method in Session instead")
 def bf_delete_reference_book(book_name):
     # type: (str) -> None
     """Deletes the reference book with the specified name for the active network."""
     bf_session.delete_reference_book(book_name)
 
 
-@deprecated(reason="Use the new delete_snapshot method in Session instead")
 def bf_delete_snapshot(name):
     # type: (str) -> None
     """
@@ -226,7 +220,6 @@ def bf_extract_answer_summary(answer_dict):
     return answer_dict["summary"]
 
 
-@deprecated(reason="Use the new fork_snapshot method in Session instead")
 def bf_fork_snapshot(base_name, name=None, overwrite=False,
                      background=False, deactivate_interfaces=None,
                      deactivate_links=None, deactivate_nodes=None,
@@ -276,7 +269,6 @@ def bf_fork_snapshot(base_name, name=None, overwrite=False,
                                      extra_args=extra_args)
 
 
-@deprecated(reason="Use the new generate_datalpane method in Session instead")
 def bf_generate_dataplane(snapshot=None, extra_args=None):
     # type: (Optional[str], Optional[Dict[str, Any]]) -> str
     """Generates the data plane for the supplied snapshot. If no snapshot argument is given, uses the last snapshot initialized."""
@@ -297,7 +289,6 @@ def bf_get_analysis_answers(name, snapshot=None,
     return answers_dict
 
 
-@deprecated(reason="Use the new get_answer method in Session instead")
 def bf_get_answer(questionName, snapshot, reference_snapshot=None):
     # type: (str, str, Optional[str]) -> Any
     """
@@ -312,7 +303,6 @@ def bf_get_answer(questionName, snapshot, reference_snapshot=None):
                                  reference_snapshot=reference_snapshot)
 
 
-@deprecated(reason="Use the new get_info method in Session instead")
 def bf_get_info():
     bf_session.get_info()
 
@@ -324,45 +314,36 @@ def bf_get_issue_config(major, minor):
         restv2helper.get_issue_config(bf_session, major, minor))
 
 
-@deprecated(
-    reason="Use the new get_node_role_dimension method in Session instead")
 def bf_get_node_role_dimension(dimension):
     # type: (str) -> NodeRoleDimension
     """Returns the definition of the given node role dimension for the active network."""
     return bf_session.get_node_role_dimension(dimension=dimension)
 
 
-@deprecated(reason="Use the new get_node_roles method in Session instead")
 def bf_get_node_roles():
     # type: () -> NodeRolesData
     """Returns the definitions of node roles for the active network."""
     return bf_session.get_node_roles()
 
 
-@deprecated(reason="Use the new get_reference_book method in Session instead")
 def bf_get_reference_book(book_name):
     # type: (str) -> ReferenceBook
     """Returns the reference book with the specified for the active network."""
     return bf_session.get_reference_book(name=book_name)
 
 
-@deprecated(
-    reason="Use the new get_reference_library method in Session instead")
 def bf_get_reference_library():
     # type: () -> ReferenceLibrary
     """Returns the reference library for the active network."""
     return bf_session.get_reference_library()
 
 
-@deprecated(reason="Use the new get_node_roles method in Session instead")
 def bf_get_snapshot_inferred_node_roles():
     # type: () -> NodeRolesData
     """Gets suggested definitions and hypothetical assignments of node roles for the active network and snapshot."""
     return bf_session.get_node_roles(inferred=True)
 
 
-@deprecated(
-    reason="Use the new get_node_role_dimension method in Session instead")
 def bf_get_snapshot_inferred_node_role_dimension(dimension):
     # type: (str) -> NodeRoleDimension
     """Gets the suggested definition and hypothetical assignments of node roles for the given inferred dimension for the active network and snapshot."""
@@ -385,7 +366,6 @@ def bf_get_snapshot_node_role_dimension(dimension):
         restv2helper.get_snapshot_node_role_dimension(bf_session, dimension))
 
 
-@deprecated(reason="Use the new get_work_status method in Session instead")
 def bf_get_work_status(wItemId):
     return bf_session.get_work_status(work_item=wItemId)
 
@@ -415,7 +395,6 @@ def bf_init_analysis(analysisName, questionDirectory):
                                     True)
 
 
-@deprecated(reason="Use the new init_snapshot method in Session instead")
 def bf_init_snapshot(upload, name=None, overwrite=False, background=False,
                      extra_args=None):
     # type: (str, Optional[str], bool, bool, Optional[Dict[str, Any]]) -> Union[str, Dict[str, str]]
@@ -492,7 +471,6 @@ def bf_list_analyses():
     return answer
 
 
-@deprecated(reason="Use the new list_networks method in Session instead")
 def bf_list_networks():
     # type: () -> List[str]
     """
@@ -503,20 +481,14 @@ def bf_list_networks():
     return bf_session.list_networks()
 
 
-@deprecated(
-    reason="Use the new list_incomplete_works method in Session instead")
 def bf_list_incomplete_works():
     return bf_session.list_incomplete_works()
 
 
-@deprecated(
-    reason="Use the new list_asked_questions method in Session instead")
 def bf_list_questions():
     return bf_session.list_asked_questions()
 
 
-@deprecated(
-    reason="Use the new list_snapshots method in Session instead")
 def bf_list_snapshots(verbose=False):
     # type: (bool) -> Union[List[str], List[Dict[str,Any]]]
     """
@@ -531,8 +503,6 @@ def bf_list_snapshots(verbose=False):
     return bf_session.list_snapshots(verbose=verbose)
 
 
-@deprecated(
-    reason="Use the new put_reference_book method in Session instead")
 def bf_put_reference_book(book):
     # type: (ReferenceBook) -> None
     """
@@ -546,8 +516,6 @@ def bf_put_reference_book(book):
     bf_session.put_reference_book(book)
 
 
-@deprecated(
-    reason="Use the new put_node_role_dimension method in Session instead")
 def bf_put_node_role_dimension(dimension):
     # type: (NodeRoleDimension) -> None
     """
@@ -564,7 +532,6 @@ def bf_put_node_role_dimension(dimension):
     bf_session.put_node_role_dimension(dimension=dimension)
 
 
-@deprecated(reason="Use the new put_node_roles method in Session instead")
 def bf_put_node_roles(node_roles_data):
     # type: (NodeRolesData) -> None
     """Writes the definitions of node roles for the active network. Completely replaces any existing definitions."""
@@ -599,7 +566,6 @@ def bf_run_analysis(name, snapshot, reference_snapshot=None, extra_args=None):
     return bf_get_analysis_answers(name, snapshot, reference_snapshot)
 
 
-@deprecated(reason="Use the new set_network method in Session instead")
 def bf_set_network(name=None, prefix=Options.default_network_prefix):
     # type: (str, str) -> str
     """
@@ -617,7 +583,6 @@ def bf_set_network(name=None, prefix=Options.default_network_prefix):
     return bf_session.set_network(name=name, prefix=prefix)
 
 
-@deprecated(reason="Use the new set_snapshot method in Session instead")
 def bf_set_snapshot(name=None, index=None):
     # type: (Optional[str], Optional[int]) -> str
     """
@@ -633,7 +598,6 @@ def bf_set_snapshot(name=None, index=None):
     return bf_session.set_snapshot(name=name, index=index)
 
 
-@deprecated(reason="Use the new upload_diagnostics method in Session instead")
 def bf_upload_diagnostics(dry_run=True, netconan_config=None):
     # type: (bool, str) -> str
     """

--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -304,7 +304,7 @@ def bf_get_answer(questionName, snapshot, reference_snapshot=None):
 
 
 def bf_get_info():
-    bf_session.get_info()
+    return bf_session.get_info()
 
 
 def bf_get_issue_config(major, minor):

--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -16,20 +16,16 @@
 
 from __future__ import absolute_import, print_function
 
-import base64
 import json
 import logging
-import os
 import tempfile
 from typing import Any, Dict, List, Optional, Union  # noqa: F401
 
 import six
 from deprecated import deprecated
-from requests import HTTPError
 
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
-from pybatfish.client.diagnostics import (_upload_diagnostics,
-                                          _warn_on_snapshot_failure)
+from pybatfish.client.diagnostics import (_warn_on_snapshot_failure)
 from pybatfish.datamodel.primitives import (  # noqa: F401
     AutoCompleteSuggestion,
     Edge, Interface,
@@ -39,12 +35,11 @@ from pybatfish.datamodel.referencelibrary import (NodeRoleDimension,
                                                   ReferenceLibrary)
 from pybatfish.exception import BatfishException
 from pybatfish.settings.issues import IssueConfig  # noqa: F401
-from pybatfish.util import (BfJsonEncoder, get_uuid, validate_name, zip_dir)
+from pybatfish.util import (BfJsonEncoder)
 from . import resthelper, restv2helper, workhelper
 from .options import Options
 from .session import Session
-from .workhelper import (get_work_status,
-                         kill_work)
+from .workhelper import (kill_work)
 
 
 def _configure_default_logging():
@@ -182,6 +177,7 @@ def bf_delete_issue_config(major, minor):
     restv2helper.delete_issue_config(bf_session, major, minor)
 
 
+@deprecated(reason="Use the new delete_network method in Session instead")
 def bf_delete_network(name):
     # type: (str) -> None
     """
@@ -190,25 +186,26 @@ def bf_delete_network(name):
     :param name: name of the network to delete
     :type name: string
     """
-    if name is None:
-        raise ValueError('Network to be deleted must be supplied')
-    jsonData = workhelper.get_data_delete_network(bf_session, name)
-    resthelper.get_json_response(bf_session, CoordConsts.SVC_RSC_DEL_NETWORK,
-                                 jsonData)
+    bf_session.delete_network(name)
 
 
+@deprecated(
+    reason="Use the new delete_node_role_dimension method in Session instead")
 def bf_delete_node_role_dimension(dimension):
     # type: (str) -> None
     """Deletes the definition of the given role dimension for the active network."""
-    restv2helper.delete_node_role_dimension(bf_session, dimension)
+    bf_session.delete_node_role_dimension(dimension)
 
 
+@deprecated(
+    reason="Use the new delete_reference_book method in Session instead")
 def bf_delete_reference_book(book_name):
     # type: (str) -> None
     """Deletes the reference book with the specified name for the active network."""
-    restv2helper.delete_reference_book(bf_session, book_name)
+    bf_session.delete_reference_book(book_name)
 
 
+@deprecated(reason="Use the new delete_snapshot method in Session instead")
 def bf_delete_snapshot(name):
     # type: (str) -> None
     """
@@ -217,12 +214,7 @@ def bf_delete_snapshot(name):
     :param name: name of the snapshot to delete
     :type name: string
     """
-    _check_network()
-    if name is None:
-        raise ValueError('Snapshot to be deleted must be supplied')
-    json_data = workhelper.get_data_delete_snapshot(bf_session, name)
-    resthelper.get_json_response(bf_session, CoordConsts.SVC_RSC_DEL_SNAPSHOT,
-                                 json_data)
+    bf_session.delete_snapshot(name)
 
 
 def bf_extract_answer_summary(answer_dict):
@@ -234,6 +226,7 @@ def bf_extract_answer_summary(answer_dict):
     return answer_dict["summary"]
 
 
+@deprecated(reason="Use the new fork_snapshot method in Session instead")
 def bf_fork_snapshot(base_name, name=None, overwrite=False,
                      background=False, deactivate_interfaces=None,
                      deactivate_links=None, deactivate_nodes=None,
@@ -271,59 +264,24 @@ def bf_fork_snapshot(base_name, name=None, overwrite=False,
         background=True, or None if the call fails
     :rtype: Union[str, Dict, None]
     """
-    if bf_session.network is None:
-        raise ValueError('Network must be set to fork a snapshot.')
-
-    if name is None:
-        name = Options.default_snapshot_prefix + get_uuid()
-    validate_name(name)
-
-    if name in bf_list_snapshots():
-        if overwrite:
-            bf_delete_snapshot(name)
-        else:
-            raise ValueError(
-                'A snapshot named ''{}'' already exists in network ''{}'''.format(
-                    name, bf_session.network))
-
-    encoded_file = None
-    if add_files is not None:
-        file_to_send = add_files
-        if os.path.isdir(add_files):
-            temp_zip_file = tempfile.NamedTemporaryFile()
-            zip_dir(add_files, temp_zip_file)
-            file_to_send = temp_zip_file.name
-
-        if os.path.isfile(file_to_send):
-            with open(file_to_send, "rb") as f:
-                encoded_file = base64.b64encode(f.read()).decode('ascii')
-
-    json_data = {
-        "snapshotBase": base_name,
-        "snapshotNew": name,
-        "deactivateInterfaces": deactivate_interfaces,
-        "deactivateLinks": deactivate_links,
-        "deactivateNodes": deactivate_nodes,
-        "restoreInterfaces": restore_interfaces,
-        "restoreLinks": restore_links,
-        "restoreNodes": restore_nodes,
-        "zipFile": encoded_file
-    }
-    restv2helper.fork_snapshot(bf_session,
-                               json_data)
-
-    return _parse_snapshot(name, background, extra_args)
+    return bf_session._fork_snapshot(base_name, name=name, overwrite=overwrite,
+                                     background=background,
+                                     deactivate_interfaces=deactivate_interfaces,
+                                     deactivate_links=deactivate_links,
+                                     deactivate_nodes=deactivate_nodes,
+                                     restore_interfaces=restore_interfaces,
+                                     restore_links=restore_links,
+                                     restore_nodes=restore_nodes,
+                                     add_files=add_files,
+                                     extra_args=extra_args)
 
 
+@deprecated(reason="Use the new generate_datalpane method in Session instead")
 def bf_generate_dataplane(snapshot=None, extra_args=None):
     # type: (Optional[str], Optional[Dict[str, Any]]) -> str
     """Generates the data plane for the supplied snapshot. If no snapshot argument is given, uses the last snapshot initialized."""
-    snapshot = bf_session.get_snapshot(snapshot)
-
-    work_item = workhelper.get_workitem_generate_dataplane(bf_session, snapshot)
-    answer_dict = workhelper.execute(work_item, bf_session,
-                                     extra_args=extra_args)
-    return str(answer_dict["status"].value)
+    return bf_session.generate_dataplane(snapshot=snapshot,
+                                         extra_args=extra_args)
 
 
 def bf_get_analysis_answers(name, snapshot=None,
@@ -339,6 +297,7 @@ def bf_get_analysis_answers(name, snapshot=None,
     return answers_dict
 
 
+@deprecated(reason="Use the new get_answer method in Session instead")
 def bf_get_answer(questionName, snapshot, reference_snapshot=None):
     # type: (str, str, Optional[str]) -> Any
     """
@@ -349,18 +308,13 @@ def bf_get_answer(questionName, snapshot, reference_snapshot=None):
     :param reference_snapshot: if present, the snapshot against which the answer
         was computed differentially.
     """
-    jsonData = workhelper.get_data_get_answer(bf_session, questionName,
-                                              snapshot, reference_snapshot)
-    response = resthelper.get_json_response(bf_session,
-                                            CoordConsts.SVC_RSC_GET_ANSWER,
-                                            jsonData)
-    answerJson = json.loads(response["answer"])
-    return answerJson
+    return bf_session.get_answer(question=questionName, snapshot=snapshot,
+                                 reference_snapshot=reference_snapshot)
 
 
+@deprecated(reason="Use the new get_info method in Session instead")
 def bf_get_info():
-    jsonResponse = resthelper.get_json_response(bf_session, '', useHttpGet=True)
-    return jsonResponse
+    bf_session.get_info()
 
 
 def bf_get_issue_config(major, minor):
@@ -370,40 +324,45 @@ def bf_get_issue_config(major, minor):
         restv2helper.get_issue_config(bf_session, major, minor))
 
 
+@deprecated(
+    reason="Use the new get_node_role_dimension method in Session instead")
 def bf_get_node_role_dimension(dimension):
     # type: (str) -> NodeRoleDimension
     """Returns the definition of the given node role dimension for the active network."""
-    return NodeRoleDimension.from_dict(
-        restv2helper.get_node_role_dimension(bf_session, dimension))
+    return bf_session.get_node_role_dimension(dimension=dimension)
 
 
+@deprecated(reason="Use the new get_node_roles method in Session instead")
 def bf_get_node_roles():
     # type: () -> NodeRolesData
     """Returns the definitions of node roles for the active network."""
-    return NodeRolesData.from_dict(restv2helper.get_node_roles(bf_session))
+    return bf_session.get_node_roles()
 
 
+@deprecated(reason="Use the new get_reference_book method in Session instead")
 def bf_get_reference_book(book_name):
     # type: (str) -> ReferenceBook
     """Returns the reference book with the specified for the active network."""
-    return ReferenceBook.from_dict(
-        restv2helper.get_reference_book(bf_session, book_name))
+    return bf_session.get_reference_book(name=book_name)
 
 
+@deprecated(
+    reason="Use the new get_reference_library method in Session instead")
 def bf_get_reference_library():
     # type: () -> ReferenceLibrary
     """Returns the reference library for the active network."""
-    return ReferenceLibrary.from_dict(
-        restv2helper.get_reference_library(bf_session))
+    return bf_session.get_reference_library()
 
 
+@deprecated(reason="Use the new get_node_roles method in Session instead")
 def bf_get_snapshot_inferred_node_roles():
     # type: () -> NodeRolesData
     """Gets suggested definitions and hypothetical assignments of node roles for the active network and snapshot."""
-    return NodeRolesData.from_dict(
-        restv2helper.get_snapshot_inferred_node_roles(bf_session))
+    return bf_session.get_node_roles(inferred=True)
 
 
+@deprecated(
+    reason="Use the new get_node_role_dimension method in Session instead")
 def bf_get_snapshot_inferred_node_role_dimension(dimension):
     # type: (str) -> NodeRoleDimension
     """Gets the suggested definition and hypothetical assignments of node roles for the given inferred dimension for the active network and snapshot."""
@@ -426,8 +385,9 @@ def bf_get_snapshot_node_role_dimension(dimension):
         restv2helper.get_snapshot_node_role_dimension(bf_session, dimension))
 
 
+@deprecated(reason="Use the new get_work_status method in Session instead")
 def bf_get_work_status(wItemId):
-    return get_work_status(wItemId, bf_session)
+    return bf_session.get_work_status(work_item=wItemId)
 
 
 def _bf_init_or_add_analysis(session, analysisName, questionDirectory,
@@ -455,6 +415,7 @@ def bf_init_analysis(analysisName, questionDirectory):
                                     True)
 
 
+@deprecated(reason="Use the new init_snapshot method in Session instead")
 def bf_init_snapshot(upload, name=None, overwrite=False, background=False,
                      extra_args=None):
     # type: (str, Optional[str], bool, bool, Optional[Dict[str, Any]]) -> Union[str, Dict[str, str]]
@@ -474,34 +435,9 @@ def bf_init_snapshot(upload, name=None, overwrite=False, background=False,
     :return: name of initialized snapshot, or JSON dictionary of task status if background=True
     :rtype: Union[str, Dict]
     """
-    if bf_session.network is None:
-        bf_set_network()
-
-    if name is None:
-        name = Options.default_snapshot_prefix + get_uuid()
-    validate_name(name)
-
-    if name in bf_list_snapshots():
-        if overwrite:
-            bf_delete_snapshot(name)
-        else:
-            raise ValueError(
-                'A snapshot named ''{}'' already exists in network ''{}'''.format(
-                    name, bf_session.network))
-
-    file_to_send = upload
-    if os.path.isdir(upload):
-        temp_zip_file = tempfile.NamedTemporaryFile()
-        zip_dir(upload, temp_zip_file)
-        file_to_send = temp_zip_file.name
-
-    json_data = workhelper.get_data_upload_snapshot(bf_session, name,
-                                                    file_to_send)
-    resthelper.get_json_response(bf_session,
-                                 CoordConsts.SVC_RSC_UPLOAD_SNAPSHOT,
-                                 json_data)
-
-    return _parse_snapshot(name, background, extra_args)
+    return bf_session._init_snapshot(upload, name=name, overwrite=overwrite,
+                                     background=background,
+                                     extra_args=extra_args)
 
 
 def _parse_snapshot(name, background, extra_args):
@@ -556,6 +492,7 @@ def bf_list_analyses():
     return answer
 
 
+@deprecated(reason="Use the new list_networks method in Session instead")
 def bf_list_networks():
     # type: () -> List[str]
     """
@@ -563,31 +500,23 @@ def bf_list_networks():
 
     :return: a list of network names
     """
-    json_data = workhelper.get_data_list_networks(bf_session)
-    json_response = resthelper.get_json_response(
-        bf_session, CoordConsts.SVC_RSC_LIST_NETWORKS, json_data)
-
-    return list(map(str, json_response['networklist']))
+    return bf_session.list_networks()
 
 
+@deprecated(
+    reason="Use the new list_incomplete_works method in Session instead")
 def bf_list_incomplete_works():
-    jsonData = workhelper.get_data_list_incomplete_work(bf_session)
-    jsonResponse = resthelper.get_json_response(bf_session,
-                                                CoordConsts.SVC_RSC_LIST_INCOMPLETE_WORK,
-                                                jsonData)
-    return jsonResponse
+    return bf_session.list_incomplete_works()
 
 
+@deprecated(
+    reason="Use the new list_asked_questions method in Session instead")
 def bf_list_questions():
-    _check_network()
-    jsonData = workhelper.get_data_list_questions(bf_session)
-    jsonResponse = resthelper.get_json_response(bf_session,
-                                                CoordConsts.SVC_RSC_LIST_QUESTIONS,
-                                                jsonData)
-    answer = jsonResponse['questionlist']
-    return answer
+    return bf_session.list_asked_questions()
 
 
+@deprecated(
+    reason="Use the new list_snapshots method in Session instead")
 def bf_list_snapshots(verbose=False):
     # type: (bool) -> Union[List[str], List[Dict[str,Any]]]
     """
@@ -599,9 +528,11 @@ def bf_list_snapshots(verbose=False):
     :return: a list of snapshot names or the full json response containing
         snapshots and metadata (if `verbose=True`)
     """
-    return restv2helper.list_snapshots(bf_session, verbose)
+    return bf_session.list_snapshots(verbose=verbose)
 
 
+@deprecated(
+    reason="Use the new put_reference_book method in Session instead")
 def bf_put_reference_book(book):
     # type: (ReferenceBook) -> None
     """
@@ -612,9 +543,11 @@ def bf_put_reference_book(book):
     :param book: The ReferenceBook object to add
     :type book: :class:`pybatfish.datamodel.referencelibrary.ReferenceBook`
     """
-    restv2helper.put_reference_book(bf_session, book)
+    bf_session.put_reference_book(book)
 
 
+@deprecated(
+    reason="Use the new put_node_role_dimension method in Session instead")
 def bf_put_node_role_dimension(dimension):
     # type: (NodeRoleDimension) -> None
     """
@@ -628,15 +561,14 @@ def bf_put_node_role_dimension(dimension):
     :param dimension: The NodeRoleDimension object for the dimension to add
     :type dimension: :class:`pybatfish.datamodel.referencelibrary.NodeRoleDimension`
     """
-    if dimension.type == "AUTO":
-        raise ValueError("Cannot put a dimension of type AUTO")
-    restv2helper.put_node_role_dimension(bf_session, dimension)
+    bf_session.put_node_role_dimension(dimension=dimension)
 
 
+@deprecated(reason="Use the new put_node_roles method in Session instead")
 def bf_put_node_roles(node_roles_data):
     # type: (NodeRolesData) -> None
     """Writes the definitions of node roles for the active network. Completely replaces any existing definitions."""
-    restv2helper.put_node_roles(bf_session, node_roles_data)
+    bf_session.put_node_roles(node_roles_data=node_roles_data)
 
 
 def bf_read_question_settings(question_class, json_path=None):
@@ -667,6 +599,7 @@ def bf_run_analysis(name, snapshot, reference_snapshot=None, extra_args=None):
     return bf_get_analysis_answers(name, snapshot, reference_snapshot)
 
 
+@deprecated(reason="Use the new set_network method in Session instead")
 def bf_set_network(name=None, prefix=Options.default_network_prefix):
     # type: (str, str) -> str
     """
@@ -681,32 +614,10 @@ def bf_set_network(name=None, prefix=Options.default_network_prefix):
     :rtype: string
     :raises BatfishException: if configuration fails
     """
-    if name is None:
-        name = prefix + get_uuid()
-    validate_name(name, "network")
-
-    try:
-        net = restv2helper.get_network(bf_session, name)
-        bf_session.network = str(net['name'])
-        return bf_session.network
-    except HTTPError as e:
-        if e.response.status_code != 404:
-            raise BatfishException('Unknown error accessing network', e)
-
-    json_data = workhelper.get_data_init_network(bf_session, name)
-    json_response = resthelper.get_json_response(
-        bf_session, CoordConsts.SVC_RSC_INIT_NETWORK, json_data)
-
-    network_name = json_response.get(CoordConsts.SVC_KEY_NETWORK_NAME)
-    if network_name is None:
-        raise BatfishException(
-            "Network initialization failed. Server response: {}".format(
-                json_response))
-
-    bf_session.network = str(network_name)
-    return bf_session.network
+    return bf_session.set_network(name=name, prefix=prefix)
 
 
+@deprecated(reason="Use the new set_snapshot method in Session instead")
 def bf_set_snapshot(name=None, index=None):
     # type: (Optional[str], Optional[int]) -> str
     """
@@ -719,35 +630,10 @@ def bf_set_snapshot(name=None, index=None):
     :return: the name of the successfully set snapshot
     :rtype: str
     """
-    if name is None and index is None:
-        raise ValueError('One of name and index must be set')
-    if name is not None and index is not None:
-        raise ValueError('Only one of name and index can be set')
-
-    snapshots = bf_list_snapshots()
-
-    # Index specified, simply give the ith snapshot
-    if index is not None:
-        if not (-len(snapshots) <= index < len(snapshots)):
-            raise IndexError(
-                "Server has only {} snapshots: {}".format(
-                    len(snapshots), snapshots))
-        bf_session.snapshot = str(snapshots[index])
-
-    # Name specified, make sure it exists.
-    else:
-        assert name is not None  # type-hint to Python
-        if name not in snapshots:
-            raise ValueError(
-                'No snapshot named ''{}'' was found in network ''{}'': {}'.format(
-                    name, bf_session.network, snapshots))
-        bf_session.snapshot = name
-
-    logging.getLogger(__name__).info("Default snapshot is now set to %s",
-                                     bf_session.snapshot)
-    return bf_session.snapshot
+    return bf_session.set_snapshot(name=name, index=index)
 
 
+@deprecated(reason="Use the new upload_diagnostics method in Session instead")
 def bf_upload_diagnostics(dry_run=True, netconan_config=None):
     # type: (bool, str) -> str
     """
@@ -773,8 +659,8 @@ def bf_upload_diagnostics(dry_run=True, netconan_config=None):
     :return: location of anonymized files (local directory if doing dry run, otherwise upload ID)
     :rtype: string
     """
-    return _upload_diagnostics(bf_session, dry_run=dry_run,
-                               netconan_config=netconan_config)
+    return bf_session.upload_diagnostics(dry_run=dry_run,
+                                         netconan_config=netconan_config)
 
 
 def bf_write_question_settings(settings, question_class, json_path=None):

--- a/pybatfish/client/diagnostics.py
+++ b/pybatfish/client/diagnostics.py
@@ -260,4 +260,23 @@ def _warn_on_snapshot_failure(session):
     :param session: Batfish session to check for snapshot failure
     :type session: :class:`~pybatfish.client.session.Session`
     """
-    session._warn_on_snapshot_failure()
+    logger = logging.getLogger(__name__)
+    statuses = _get_snapshot_parse_status(session)
+    if _check_if_any_failed(statuses):
+        logger.warning("""\
+Your snapshot was initialized but Batfish failed to parse one or more input files. You can proceed but some analyses may be incorrect. You can help the Batfish developers improve support for your network by running:
+
+    bf_upload_diagnostics(dry_run=False)
+
+to share private, anonymized information. For more information, see the documentation with:
+
+    help(bf_upload_diagnostics)""")
+    elif not _check_if_all_passed(statuses):
+        logger.warning("""\
+Your snapshot was successfully initialized but Batfish failed to fully recognized some lines in one or more input files. Some unrecognized configuration lines are not uncommon for new networks, and it is often fine to proceed with further analysis. You can help the Batfish developers improve support for your network by running:
+
+    bf_upload_diagnostics(dry_run=False)
+
+to share private, anonymized information. For more information, see the documentation with:
+
+    help(bf_upload_diagnostics)""")

--- a/pybatfish/client/diagnostics.py
+++ b/pybatfish/client/diagnostics.py
@@ -260,23 +260,4 @@ def _warn_on_snapshot_failure(session):
     :param session: Batfish session to check for snapshot failure
     :type session: :class:`~pybatfish.client.session.Session`
     """
-    logger = logging.getLogger(__name__)
-    statuses = _get_snapshot_parse_status(session)
-    if _check_if_any_failed(statuses):
-        logger.warning("""\
-Your snapshot was initialized but Batfish failed to parse one or more input files. You can proceed but some analyses may be incorrect. You can help the Batfish developers improve support for your network by running:
-
-    bf_upload_diagnostics(dry_run=False)
-
-to share private, anonymized information. For more information, see the documentation with:
-
-    help(bf_upload_diagnostics)""")
-    elif not _check_if_all_passed(statuses):
-        logger.warning("""\
-Your snapshot was successfully initialized but Batfish failed to fully recognized some lines in one or more input files. Some unrecognized configuration lines are not uncommon for new networks, and it is often fine to proceed with further analysis. You can help the Batfish developers improve support for your network by running:
-
-    bf_upload_diagnostics(dry_run=False)
-
-to share private, anonymized information. For more information, see the documentation with:
-
-    help(bf_upload_diagnostics)""")
+    session._warn_on_snapshot_failure()

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -214,7 +214,7 @@ class Session(object):
                       deactivate_nodes=None, restore_interfaces=None,
                       restore_links=None, restore_nodes=None, add_files=None,
                       extra_args=None):
-        # type: (str, Optional[str], bool, Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Union[str, Dict, None]
+        # type: (str, Optional[str], bool, Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Union[str, None]
         """
         Copy an existing snapshot and deactivate or reactivate specified interfaces, nodes, and links on the copy.
 
@@ -241,9 +241,8 @@ class Session(object):
         :type add_files: str
         :param extra_args: extra arguments to be passed to the parse command.
         :type extra_args: dict
-        :return: name of initialized snapshot, JSON dictionary of task status if
-            background=True, or None if the call fails
-        :rtype: Union[str, Dict, None]
+        :return: name of initialized snapshot or None if the call fails
+        :rtype: Union[str, None]
         """
         return self._fork_snapshot(base_name, name=name, overwrite=overwrite,
                                    deactivate_interfaces=deactivate_interfaces,
@@ -439,7 +438,7 @@ class Session(object):
 
     def init_snapshot(self, upload, name=None, overwrite=False,
                       extra_args=None):
-        # type: (str, Optional[str], bool, Optional[Dict[str, Any]]) -> Union[str, Dict[str, str]]
+        # type: (str, Optional[str], bool, Optional[Dict[str, Any]]) -> str
         """
         Initialize a new snapshot.
 
@@ -452,8 +451,8 @@ class Session(object):
         :type overwrite: bool
         :param extra_args: extra arguments to be passed to the parse command.
         :type extra_args: dict
-        :return: name of initialized snapshot, or JSON dictionary of task status if background=True
-        :rtype: Union[str, Dict]
+        :return: name of initialized snapshot
+        :rtype: str
         """
         return self._init_snapshot(upload, name=name, overwrite=overwrite,
                                    extra_args=extra_args)

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -393,7 +393,6 @@ class Session(object):
         :return: the definitions of node roles for the active network, or inferred definitions for the active snapshot if inferred=True.
         :rtype: :class:`~pybatfish.datamodel.referencelibrary.NodeRolesData`
         """
-        # TODO finish/format docstring
         if inferred:
             self._check_snapshot()
             return NodeRolesData.from_dict(
@@ -402,7 +401,12 @@ class Session(object):
 
     def get_reference_book(self, name):
         # type: (str) -> ReferenceBook
-        """Returns the specified reference book for the active network."""
+        """
+        Returns the specified reference book for the active network.
+
+        :param name: name of the reference book to fetch
+        :type name: str
+        """
         return ReferenceBook.from_dict(
             restv2helper.get_reference_book(self, name))
 
@@ -490,6 +494,7 @@ class Session(object):
         List networks the session's API key can access.
 
         :return: a list of network names
+        :rtype: list
         """
         json_data = workhelper.get_data_list_networks(self)
         json_response = resthelper.get_json_response(
@@ -499,7 +504,12 @@ class Session(object):
 
     def list_incomplete_works(self):
         # type: () -> Dict[str, Any]
-        """Get pending work that is incomplete."""
+        """
+        Get pending work that is incomplete.
+
+        :return: JSON dictionary of question name to question object
+        :rtype: dict
+        """
         json_data = workhelper.get_data_list_incomplete_work(self)
         response = resthelper.get_json_response(self,
                                                 CoordConsts.SVC_RSC_LIST_INCOMPLETE_WORK,
@@ -508,7 +518,12 @@ class Session(object):
 
     def list_asked_questions(self):
         # type: () -> Dict[str, Any]
-        """Get questions asked about this network."""
+        """
+        Get questions asked about this network.
+
+        :return: JSON dictionary of question name to question object
+        :rtype: dict
+        """
         self._check_network()
         json_data = workhelper.get_data_list_questions(self)
         response = resthelper.get_json_response(self,
@@ -523,9 +538,11 @@ class Session(object):
 
         :param verbose: If true, return the full output of Batfish, including
             snapshot metadata.
+        :type verbose: bool
 
         :return: a list of snapshot names or the full json response containing
             snapshots and metadata (if `verbose=True`)
+        :rtype: list
         """
         return restv2helper.list_snapshots(self, verbose)
 
@@ -560,7 +577,12 @@ class Session(object):
 
     def put_node_roles(self, node_roles_data):
         # type: (NodeRolesData) -> None
-        """Writes the definitions of node roles for the active network. Completely replaces any existing definitions."""
+        """
+        Writes the definitions of node roles for the active network. Completely replaces any existing definitions.
+
+        :param node_roles_data: node roles definitions to add to the active network
+        :type node_roles_data: :class:`~pybatfish.datamodel.referencelibrary.NodeRolesData`
+        """
         restv2helper.put_node_roles(self, node_roles_data)
 
     def set_network(self, name=None, prefix=Options.default_network_prefix):

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -27,10 +27,8 @@ from requests import HTTPError
 
 from pybatfish.client import resthelper, restv2helper, workhelper
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
-from pybatfish.client.diagnostics import (_check_if_all_passed,
-                                          _check_if_any_failed,
-                                          _get_snapshot_parse_status,
-                                          _upload_diagnostics)
+from pybatfish.client.diagnostics import (_upload_diagnostics,
+                                          _warn_on_snapshot_failure)
 from pybatfish.client.workhelper import get_work_status
 from pybatfish.datamodel import (Edge, Interface, NodeRoleDimension,
                                  NodeRolesData, ReferenceBook,
@@ -753,35 +751,6 @@ class Session(object):
                 "Default snapshot is now set to %s",
                 self.snapshot)
             if self.enable_diagnostics:
-                self._warn_on_snapshot_failure()
+                _warn_on_snapshot_failure(self)
 
             return self.snapshot
-
-    def _warn_on_snapshot_failure(self):
-        # type: (Session) -> None
-        """
-        Check if snapshot passed and warn about any parsing or conversion issues.
-
-        :param session: Batfish session to check for snapshot failure
-        :type session: :class:`~pybatfish.client.session.Session`
-        """
-        logger = logging.getLogger(__name__)
-        statuses = _get_snapshot_parse_status(self)
-        if _check_if_any_failed(statuses):
-            logger.warning("""\
-    Your snapshot was initialized but Batfish failed to parse one or more input files. You can proceed but some analyses may be incorrect. You can help the Batfish developers improve support for your network by running:
-
-        bf_upload_diagnostics(dry_run=False)
-
-    to share private, anonymized information. For more information, see the documentation with:
-
-        help(bf_upload_diagnostics)""")
-        elif not _check_if_all_passed(statuses):
-            logger.warning("""\
-    Your snapshot was successfully initialized but Batfish failed to fully recognized some lines in one or more input files. Some unrecognized configuration lines are not uncommon for new networks, and it is often fine to proceed with further analysis. You can help the Batfish developers improve support for your network by running:
-
-        bf_upload_diagnostics(dry_run=False)
-
-    to share private, anonymized information. For more information, see the documentation with:
-
-        help(bf_upload_diagnostics)""")

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -27,11 +27,14 @@ from requests import HTTPError
 
 from pybatfish.client import workhelper, resthelper, restv2helper
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
-from pybatfish.client.diagnostics import _get_snapshot_parse_status, \
-    _check_if_any_failed, _check_if_all_passed, _upload_diagnostics
+from pybatfish.client.diagnostics import (_get_snapshot_parse_status,
+                                          _check_if_any_failed,
+                                          _check_if_all_passed,
+                                          _upload_diagnostics)
 from pybatfish.client.workhelper import get_work_status
-from pybatfish.datamodel import Interface, Edge, NodeRolesData, \
-    NodeRoleDimension, ReferenceBook, ReferenceLibrary
+from pybatfish.datamodel import (Interface, Edge, NodeRolesData,
+                                 NodeRoleDimension, ReferenceBook,
+                                 ReferenceLibrary)
 from pybatfish.exception import BatfishException
 from pybatfish.util import validate_name, get_uuid, zip_dir
 from .options import Options

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -710,12 +710,13 @@ class Session(object):
     def _check_network(self):
         """Check if current network is set."""
         if self.network is None:
-            raise BatfishException("Network is not set")
+            raise ValueError("Network is not set")
 
     def _check_snapshot(self):
         """Check if current snapshot (and network) is set."""
-        if self.network is None:
-            raise BatfishException("Network is not set")
+        self._check_network()
+        if self.snapshot is None:
+            raise ValueError("Snapshot is not set")
 
     def _parse_snapshot(self, name, background, extra_args):
         # type: (str, bool, Optional[Dict[str, Any]]) -> Union[str, Dict[str, str]]


### PR DESCRIPTION
* Moved functionality for some `bf_<cmds>` in `commands.py` into `Session` object
  * Removed background flag from public, replacement methods
* Consolidated some `get_node_role...` functions down into two core functions (`get_node_role_dimension`, `get_node_roles`)
* A few docstring updates at the same time, more to come in the future

Deferred `@deprecated` annotation for now, to avoid affecting notebooks
