### PR TITLE
Include all questions when running list_questions from pybatfish

### DIFF
--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -314,9 +314,12 @@ def get_data_list_incomplete_work(session):
     return json_data
 
 
-def get_data_list_questions(session):
+def get_data_list_questions(session, verbose=True):
     json_data = {CoordConsts.SVC_KEY_API_KEY: session.api_key,
-                 CoordConsts.SVC_KEY_NETWORK_NAME: session.network}
+                 CoordConsts.SVC_KEY_NETWORK_NAME: session.network,
+                 # Pybatfish questions (leading `__`) are ignored by default
+                 # Use verbose flag to include these
+                 CoordConsts.SVC_KEY_VERBOSE: str(verbose)}
     return json_data
 
 

--- a/tests/integration/test_answer_funcs.py
+++ b/tests/integration/test_answer_funcs.py
@@ -18,7 +18,8 @@ import pytest
 
 from pybatfish.client.commands import (bf_delete_network, bf_get_work_status,
                                        bf_init_analysis, bf_init_snapshot,
-                                       bf_session, bf_set_network)
+                                       bf_list_questions, bf_session,
+                                       bf_set_network)
 from pybatfish.datamodel.flow import HeaderConstraints
 from pybatfish.exception import BatfishException
 from pybatfish.question import bfq
@@ -80,6 +81,13 @@ def test_answer_fail(network):
 def test_init_analysis(network):
     """Ensure bf_init_analysis does not crash."""
     bf_init_analysis("test_analysis", _stable_question_dir)
+
+
+def test_list_questions(network):
+    """Make sure answered question shows up in list_questions."""
+    question = bfq.ipOwners()
+    question.answer()
+    assert question.get_name() in bf_list_questions()
 
 
 def test_answer_traceroute(traceroute_network):


### PR DESCRIPTION
Batfish `list_questions` API ignores questions with leading `__` by default.  Pybatfish generates question names including a leading `__`.

This means questions asked in Pybatfish do not show up when listing asked questions from Pybatfish.

This PR updates list questions call in Pybatfish to explicitly include all questions.
