### PR TITLE
Add question functions into Session

### DIFF
--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -20,10 +20,9 @@ import json
 import logging
 import os
 import tempfile
-from typing import (Any, Dict, Iterable, List, Optional, Set,  # noqa: F401
+from typing import (Any, Dict, List, Optional,  # noqa: F401
                     Text, Union)
 
-import six
 from deprecated import deprecated
 from requests import HTTPError
 
@@ -36,10 +35,7 @@ from pybatfish.datamodel import (Edge, Interface, NodeRoleDimension,
                                  NodeRolesData, ReferenceBook,
                                  ReferenceLibrary)
 from pybatfish.exception import BatfishException
-from pybatfish.question.question import (_install_questions,
-                                         _list_questions,
-                                         _load_questions_from_dir,
-                                         _load_remote_questions_templates)
+from pybatfish.question.question import (Questions)
 from pybatfish.util import get_uuid, validate_name, zip_dir
 from .options import Options
 
@@ -75,7 +71,8 @@ class Session(object):
         self.snapshot = None  # type: Optional[str]
 
         # Object to hold questions
-        self.q = type('q', (object,), {})  # type: object
+        # self.q = type('q', (object,), {})  # type: object
+        self.q = Questions(self)
 
         # Additional worker args
         self.additional_args = {}  # type: Dict
@@ -538,28 +535,6 @@ class Session(object):
                                                 json_data)
         return response
 
-    def list_question_tags(self):
-        # type: () -> Set[str]
-        """
-        Get the tags for available questions.
-
-        :return: tags for available questions
-        :rtype: set
-        """
-        return {t for q in self.list_questions() for t in q.get('tags', [])}
-
-    def list_questions(self, tags=None):
-        # type: (Optional[Iterable[str]]) -> List[Dict[str, Union[str, Set]]]
-        """
-        List questions available in this session.
-
-        :param tags: if not `None`, only list questions with specified tags
-            See :py:func:`list_question_tags` for a list of tags for available questions.
-        :type tags: Iterable[str]
-        :return: list of question dict, containing "name", "description", and "tags"
-        """
-        return _list_questions(tags, self.q)
-
     def list_snapshots(self, verbose=False):
         # type: (bool) -> Union[List[str], List[Dict[str,Any]]]
         """
@@ -574,20 +549,6 @@ class Session(object):
         :rtype: list
         """
         return restv2helper.list_snapshots(self, verbose)
-
-    def load_questions(self, directory=None):
-        # type: (Optional[str]) -> None
-        """
-        Load questions from Batfish service or local directory into this session.
-
-        :param directory: optional directory to load questions from, if none is specified, questions are loaded from the Batfish service instead
-        :type directory: str
-        """
-        if directory:
-            questions = six.iteritems(_load_questions_from_dir(directory, self))
-            _install_questions(questions, self.q)
-        else:
-            _install_questions(_load_remote_questions_templates(self), self.q)
 
     def put_reference_book(self, book):
         # type: (ReferenceBook) -> None

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -70,8 +70,7 @@ class Session(object):
         self.network = None  # type: Optional[str]
         self.snapshot = None  # type: Optional[str]
 
-        # Object to hold questions
-        # self.q = type('q', (object,), {})  # type: object
+        # Object to hold and manage questions
         self.q = Questions(self)
 
         # Additional worker args

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -259,10 +259,10 @@ class Questions(object):
     def list(self, tags=None):
         # type: (Optional[Iterable[str]]) -> List[Dict[str, Union[str, Set]]]
         """
-        List questions available in this session.
+        List available questions.
 
         :param tags: if not `None`, only list questions with specified tags
-            See :py:func:`list_question_tags` for a list of tags for available questions.
+            See :py:func:`list_tags` for a list of tags for available questions.
         :type tags: Iterable[str]
         :return: list of question dict, containing "name", "description", and "tags"
         """

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -252,12 +252,17 @@ def list_questions(tags=None, question_module='pybatfish.question.bfq'):
     :returns: a list of questions, where each question is represented as a dict
         containing "name", "description", and "tags".
     """
-    module = sys.modules[question_module]
+    return _list_questions(tags, sys.modules[question_module])
+
+
+def _list_questions(tags, obj):
+    # type: (Optional[Iterable[str]], object) -> List[Dict[str, Union[str, Set]]]
+    """List questions in the specified object, optionally filtering on supplied tags."""
     # Members of the module are (name,value) pairs so
     # x[1] in the lambda represents the value part.
     # Want members with value of type QuestionMeta
     predicate = lambda x: isinstance(x[1], QuestionMeta)
-    question_functions = filter(predicate, getmembers(module))
+    question_functions = filter(predicate, getmembers(obj))
 
     matching_questions = []
     desired_tags = set(
@@ -289,6 +294,13 @@ def _install_questions_in_module(questions, module_name):
     for (name, question_class) in questions:
         setattr(question_class, '__module__', module_name)
         setattr(module, name, question_class)
+
+
+def _install_questions(questions, obj):
+    # type: (Iterable[Tuple[str, QuestionMeta]], object) -> None
+    """Install the given questions in the specified object."""
+    for (name, question_class) in questions:
+        setattr(obj, name, question_class)
 
 
 def _load_questions_from_dir(question_dir, session):

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -240,6 +240,52 @@ class QuestionBase(object):
         return self
 
 
+class Questions(object):
+    """Class to hold and manage (e.g. load, list) Batfish questions."""
+
+    def __init__(self, session):
+        self._session = session
+
+    def list_tags(self):
+        # type: () -> Set[str]
+        """
+        Get the tags for available questions.
+
+        :return: tags for available questions
+        :rtype: set
+        """
+        return {t for q in self.list() for t in q.get('tags', [])}
+
+    def list(self, tags=None):
+        # type: (Optional[Iterable[str]]) -> List[Dict[str, Union[str, Set]]]
+        """
+        List questions available in this session.
+
+        :param tags: if not `None`, only list questions with specified tags
+            See :py:func:`list_question_tags` for a list of tags for available questions.
+        :type tags: Iterable[str]
+        :return: list of question dict, containing "name", "description", and "tags"
+        """
+        return _list_questions(tags, self)
+
+    def load(self, directory=None):
+        # type: (Optional[str]) -> None
+        """
+        Load questions from Batfish service or local directory.
+
+        :param directory: optional directory to load questions from, if none is specified, questions are loaded from the Batfish service instead
+        :type directory: str
+        """
+        if directory:
+            _install_questions(
+                six.iteritems(
+                    _load_questions_from_dir(directory, self._session)),
+                self)
+        else:
+            _install_questions(_load_remote_questions_templates(self._session),
+                               self)
+
+
 def list_questions(tags=None, question_module='pybatfish.question.bfq'):
     # type: (Optional[Iterable[str]], str) -> List[Dict[str, Union[str, Set]]]
     """List available questions.

--- a/tests/client/test_questions.py
+++ b/tests/client/test_questions.py
@@ -1,0 +1,118 @@
+#   Copyright 2018 The Batfish Open Source Project
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import json
+import os
+
+import pytest
+
+from pybatfish.client.session import Session
+from pybatfish.question.question import (QuestionBase, QuestionMeta,
+                                         _install_questions)
+
+
+def create_question(name, session, description, tags):
+    return (name, QuestionMeta(name, (QuestionBase,), {
+        'docstring': 'docstring',
+        'description': description,
+        'session': session,
+        'tags': tags,
+        'template': {},
+        'variables': [],
+    }))
+
+
+@pytest.fixture(scope='function')
+def session():
+    s = Session()
+    yield s
+
+
+@pytest.fixture(scope='module')
+def questions():
+    """Basic pseudo-questions for questions tests."""
+    q1 = {
+        'name': 'qName1',
+        'description': 'description1.',
+        'tags': ['tag1'],
+    }
+    q2 = {
+        'name': 'qName2',
+        'description': 'description2.',
+        'tags': ['tags2'],
+    }
+    yield [q1, q2]
+
+
+def test_list_question_tags(session):
+    """Test that question tags are listed as expected."""
+    # Should have no tags to start with
+    assert len(session.list_question_tags()) == 0
+
+    q1_tags = ['tag1', 'tag2']
+    q3_tags = ['tag2']
+    all_tags = set()
+    all_tags.update(q1_tags)
+    all_tags.update(q3_tags)
+
+    q1 = create_question('qName1', session, 'description', q1_tags)
+    q2 = create_question('qName2', session, 'description', [])
+    q3 = create_question('qName3', session, 'description', q3_tags)
+    _install_questions([q1, q2, q3], session.q)
+
+    # Make sure all tags show up when listing tags
+    assert all_tags == session.list_question_tags()
+
+
+def test_list_questions(session, questions):
+    """Test that questions are listed as expected."""
+    # Should have no questions to start with
+    assert len(session.list_questions()) == 0
+
+    qs = [create_question(q.get('name'), session, q.get('description'),
+                          q.get('tags')) for q in questions]
+    _install_questions(qs, session.q)
+
+    # Make sure all questions show up when listing questions
+    listed_questions = session.list_questions()
+    for q in questions:
+        assert q in listed_questions
+
+
+def test_load_questions_local(session, tmpdir, questions):
+    """Test that questions loaded from a directory show up as expected."""
+    # Should have no questions to start with
+    assert len(session.list_questions()) == 0
+
+    # Should still have no questions after loading an empty dir
+    dir_path = str(tmpdir.mkdir('questions'))
+    session.load_questions(dir_path)
+
+    for q in questions:
+        filename = '{}.json'.format(q['name'])
+        with open(os.path.join(dir_path, filename), 'w') as f:
+            f.write(json.dumps({
+                'class': 'class',
+                'instance': {
+                    'description': q['description'],
+                    'instanceName': q['name'],
+                    'tags': q['tags'],
+                }
+            }))
+            f.flush()
+    session.load_questions(dir_path)
+
+    # Make sure all questions from specified directory show up when listing questions
+    listed_questions = session.list_questions()
+    for q in questions:
+        assert q in listed_questions

--- a/tests/client/test_questions.py
+++ b/tests/client/test_questions.py
@@ -98,6 +98,7 @@ def test_load_questions_local(session, tmpdir, questions):
     # Should still have no questions after loading an empty dir
     dir_path = str(tmpdir.mkdir('questions'))
     session.q.load(dir_path)
+    assert len(session.q.list()) == 0
 
     for q in questions:
         filename = '{}.json'.format(q['name'])

--- a/tests/client/test_questions.py
+++ b/tests/client/test_questions.py
@@ -22,6 +22,7 @@ from pybatfish.question.question import (QuestionBase, QuestionMeta,
 
 
 def create_question(name, session, description, tags):
+    """Create question to manually install into Session.q."""
     return (name, QuestionMeta(name, (QuestionBase,), {
         'docstring': 'docstring',
         'description': description,
@@ -30,12 +31,6 @@ def create_question(name, session, description, tags):
         'template': {},
         'variables': [],
     }))
-
-
-@pytest.fixture(scope='function')
-def session():
-    s = Session()
-    yield s
 
 
 @pytest.fixture(scope='module')
@@ -52,6 +47,12 @@ def questions():
         'tags': ['tags2'],
     }
     yield [q1, q2]
+
+
+@pytest.fixture(scope='function')
+def session():
+    s = Session()
+    yield s
 
 
 def test_list_question_tags(session):

--- a/tests/client/test_questions.py
+++ b/tests/client/test_questions.py
@@ -55,10 +55,10 @@ def session():
     yield s
 
 
-def test_list_question_tags(session):
+def test_list_tags(session):
     """Test that question tags are listed as expected."""
     # Should have no tags to start with
-    assert len(session.list_question_tags()) == 0
+    assert len(session.q.list_tags()) == 0
 
     q1_tags = ['tag1', 'tag2']
     q3_tags = ['tag2']
@@ -72,20 +72,20 @@ def test_list_question_tags(session):
     _install_questions([q1, q2, q3], session.q)
 
     # Make sure all tags show up when listing tags
-    assert all_tags == session.list_question_tags()
+    assert all_tags == session.q.list_tags()
 
 
 def test_list_questions(session, questions):
     """Test that questions are listed as expected."""
     # Should have no questions to start with
-    assert len(session.list_questions()) == 0
+    assert len(session.q.list()) == 0
 
     qs = [create_question(q.get('name'), session, q.get('description'),
                           q.get('tags')) for q in questions]
     _install_questions(qs, session.q)
 
     # Make sure all questions show up when listing questions
-    listed_questions = session.list_questions()
+    listed_questions = session.q.list()
     for q in questions:
         assert q in listed_questions
 
@@ -93,11 +93,11 @@ def test_list_questions(session, questions):
 def test_load_questions_local(session, tmpdir, questions):
     """Test that questions loaded from a directory show up as expected."""
     # Should have no questions to start with
-    assert len(session.list_questions()) == 0
+    assert len(session.q.list()) == 0
 
     # Should still have no questions after loading an empty dir
     dir_path = str(tmpdir.mkdir('questions'))
-    session.load_questions(dir_path)
+    session.q.load(dir_path)
 
     for q in questions:
         filename = '{}.json'.format(q['name'])
@@ -111,9 +111,9 @@ def test_load_questions_local(session, tmpdir, questions):
                 }
             }))
             f.flush()
-    session.load_questions(dir_path)
+    session.q.load(dir_path)
 
     # Make sure all questions from specified directory show up when listing questions
-    listed_questions = session.list_questions()
+    listed_questions = session.q.list()
     for q in questions:
         assert q in listed_questions


### PR DESCRIPTION
* Add `Questions` class with question functions (list, load, list_tags)
* When called, load questions will load into `Questions` obj inside `Session` instead of `bfq`
* Add some basic tests

Now, you can run:
```
> bf = Session()
> bf.set_network(NETWORK_NAME)
> bf.init_snapshot(...)
'snapshot_name'
> bf.q.load()
> bf.q.list()
[{'name': 'qName', ...
> bf.q.nodeProperties().answer()
<table answer>
```
old-style usage still works as well:
```
> bf_set_network(NETWORK_NAME)
> bf_init_snapshot(...)
'snapshot_name'
> load_questions()
> list_questions()
[{'name': 'qName', ...
> bfq.nodeProperties().answer()
<table answer>
```
