### PR TITLE
Update module and func names for diagnostics

### DIFF
--- a/pybatfish/client/_diagnostics.py
+++ b/pybatfish/client/_diagnostics.py
@@ -65,10 +65,10 @@ _S3_BUCKET = 'batfish-diagnostics'
 _S3_REGION = 'us-west-2'
 
 
-def _upload_diagnostics(session, bucket=_S3_BUCKET, region=_S3_REGION,
-                        dry_run=True,
-                        netconan_config=None, questions=_INIT_INFO_QUESTIONS,
-                        resource_prefix=''):
+def upload_diagnostics(session, bucket=_S3_BUCKET, region=_S3_REGION,
+                       dry_run=True,
+                       netconan_config=None, questions=_INIT_INFO_QUESTIONS,
+                       resource_prefix=''):
     # type: (Session, str, str, bool, Optional[str], Iterable[Dict[str, object]], str) -> str
     """
     Fetch, anonymize, and optionally upload snapshot initialization information.
@@ -252,7 +252,7 @@ def _upload_dir_to_url(base_url, src_dir, headers=None):
                             resource, r.status_code))
 
 
-def _warn_on_snapshot_failure(session):
+def warn_on_snapshot_failure(session):
     # type: (Session) -> None
     """
     Check if snapshot passed and warn about any parsing or conversion issues.

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -26,9 +26,9 @@ from deprecated import deprecated
 from requests import HTTPError
 
 from pybatfish.client import resthelper, restv2helper, workhelper
+from pybatfish.client._diagnostics import (upload_diagnostics,
+                                           warn_on_snapshot_failure)
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
-from pybatfish.client.diagnostics import (_upload_diagnostics,
-                                          _warn_on_snapshot_failure)
 from pybatfish.client.workhelper import get_work_status
 from pybatfish.datamodel import (Edge, Interface, NodeRoleDimension,
                                  NodeRolesData, ReferenceBook,
@@ -688,8 +688,8 @@ class Session(object):
         :return: location of anonymized files (local directory if doing dry run, otherwise upload ID)
         :rtype: string
         """
-        return _upload_diagnostics(self, dry_run=dry_run,
-                                   netconan_config=netconan_config)
+        return upload_diagnostics(self, dry_run=dry_run,
+                                  netconan_config=netconan_config)
 
     def _check_network(self):
         """Check if current network is set."""
@@ -737,6 +737,6 @@ class Session(object):
                 "Default snapshot is now set to %s",
                 self.snapshot)
             if self.enable_diagnostics:
-                _warn_on_snapshot_failure(self)
+                warn_on_snapshot_failure(self)
 
             return self.snapshot

--- a/tests/client/test_diagnostics.py
+++ b/tests/client/test_diagnostics.py
@@ -20,9 +20,9 @@ import uuid
 import pytest
 import responses
 
-from pybatfish.client.diagnostics import (_anonymize_dir, _check_if_all_passed,
-                                          _check_if_any_failed,
-                                          _upload_dir_to_url)
+from pybatfish.client._diagnostics import (_anonymize_dir, _check_if_all_passed,
+                                           _check_if_any_failed,
+                                           _upload_dir_to_url)
 
 # Config file constants for anonymization and upload
 _CONFIG_IP_ADDR = "1.2.3.4"

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -17,11 +17,11 @@ from os.path import abspath, dirname, join, pardir, realpath
 import pytest
 import requests
 
+from pybatfish.client._diagnostics import (_INIT_INFO_QUESTIONS, _S3_BUCKET,
+                                           _S3_REGION, upload_diagnostics)
 from pybatfish.client.commands import (bf_delete_network,
                                        bf_delete_snapshot, bf_init_snapshot,
                                        bf_session, bf_set_network)
-from pybatfish.client.diagnostics import (_INIT_INFO_QUESTIONS, _S3_BUCKET,
-                                          _S3_REGION, _upload_diagnostics)
 from pybatfish.question.question import QuestionBase
 
 _this_dir = abspath(dirname(realpath(__file__)))
@@ -56,8 +56,8 @@ def test_questions(network, example_snapshot):
 def test_upload_diagnostics(network, example_snapshot):
     """Upload initialization information for example snapshot."""
     # This call raises an exception if any file upload results in HTTP status != 200
-    resource = _upload_diagnostics(session=bf_session, dry_run=False,
-                                   resource_prefix='test/')
+    resource = upload_diagnostics(session=bf_session, dry_run=False,
+                                  resource_prefix='test/')
     base_url = 'https://{bucket}.s3-{region}.amazonaws.com'.format(
         bucket=_S3_BUCKET, region=_S3_REGION)
 

--- a/tests/integration/test_snapshot_funcs.py
+++ b/tests/integration/test_snapshot_funcs.py
@@ -17,6 +17,7 @@ from os.path import abspath, dirname, join, pardir, realpath
 import pytest
 from requests import HTTPError
 
+from pybatfish.client._diagnostics import (_get_snapshot_parse_status)
 from pybatfish.client.commands import (bf_delete_network,
                                        bf_delete_snapshot, bf_fork_snapshot,
                                        bf_generate_dataplane,
@@ -29,7 +30,6 @@ from pybatfish.client.commands import (bf_delete_network,
                                        bf_session, bf_set_network,
                                        bf_set_snapshot)
 from pybatfish.client.consts import BfConsts
-from pybatfish.client.diagnostics import (_get_snapshot_parse_status)
 from pybatfish.client.extended import (bf_get_snapshot_input_object_text,
                                        bf_get_snapshot_object_text,
                                        bf_put_snapshot_object)


### PR DESCRIPTION
* Make `diagnostics` module "private"
* Update functions in `diagnostics` module to use better "public" / "private" naming (e.g. `upload_diagnostics` is exposed to be used elsewhere in Pybatfish, so make it "public")