### PR TITLE
Update asserts to accept session

### DIFF
--- a/pybatfish/client/asserts.py
+++ b/pybatfish/client/asserts.py
@@ -267,9 +267,10 @@ def assert_filter_denies(filter_name, headers, startLocation=None, soft=False,
 
 def _get_question_object(session, name):
     """
-    Get the question object for the specified session, containing the specified question name.
+    Get the question object corresponding to the specified question name.
 
-    Falls back to bfq if it contains the question and specified session does not.
+    First searches the specified session, but falls back to bfq if it contains
+    the question and specified session does not.
     """
     # If no session was specified or it doesn't have the specified question
     # (e.g. questions were loaded with load_questions()), use bfq for reverse

--- a/pybatfish/client/asserts.py
+++ b/pybatfish/client/asserts.py
@@ -269,7 +269,7 @@ def _get_question_object(session, name):
     """
     Get the question object for the specified session, containing the specified question name.
 
-    Falls back to bfq contains the question and session does not.
+    Falls back to bfq if it contains the question and specified session does not.
     """
     # If no session was specified or it doesn't have the specified question
     # (e.g. questions were loaded with load_questions()), use bfq for reverse

--- a/pybatfish/client/asserts.py
+++ b/pybatfish/client/asserts.py
@@ -266,6 +266,7 @@ def assert_filter_denies(filter_name, headers, startLocation=None, soft=False,
 
 
 def _get_question_object(session, name):
+    # type: (Optional[Session], str) -> Any
     """
     Get the question object corresponding to the specified question name.
 

--- a/tests/client/test_assert.py
+++ b/tests/client/test_assert.py
@@ -196,5 +196,6 @@ def test_get_question_object():
     # Cannot find the question we're searching for
     with patch.object(bf.q, 'otherName', create=True):
         with patch.object(bfq, 'otherOtherName', create=True):
-            with pytest.raises(BatfishException):
+            with pytest.raises(BatfishException) as err:
                 _get_question_object(bf, 'qName')
+            assert 'qName question was not found' in str(err.value)

--- a/tests/client/test_assert.py
+++ b/tests/client/test_assert.py
@@ -15,9 +15,9 @@ import pytest
 import six
 from pandas import DataFrame
 
-from pybatfish.client.asserts import (_raise_common, assert_filter_denies,
-                                      assert_filter_permits,
-                                      _get_question_object)
+from pybatfish.client.asserts import (_get_question_object, _raise_common,
+                                      assert_filter_denies,
+                                      assert_filter_permits)
 from pybatfish.client.session import Session
 from pybatfish.datamodel import HeaderConstraints
 from pybatfish.datamodel.answer import TableAnswer
@@ -179,7 +179,6 @@ def test_filter_denies_no_session():
 
 def test_get_question_object():
     """Confirm _get_question_object identifies the correct question object based on the specified session and the questions it contains."""
-
     # Session contains the question we're searching for
     bf = Session()
     with patch.object(bf.q, 'qName', create=True):

--- a/tests/client/test_assert.py
+++ b/tests/client/test_assert.py
@@ -64,7 +64,7 @@ class MockQuestion(QuestionBase):
 
 
 def test_filter_permits():
-    """Confirm filter permits assert passes and fails as expected when specifying a session."""
+    """Confirm filter-permits assert passes and fails as expected when specifying a session."""
     headers = HeaderConstraints(srcIps='1.1.1.1')
     bf = Session()
     with patch.object(bf.q, 'searchFilters',
@@ -92,7 +92,7 @@ def test_filter_permits():
 
 def test_filter_permits_no_session():
     """
-    Confirm filter permit assert passes and fails as expected when not specifying a session.
+    Confirm filter-permits assert passes and fails as expected when not specifying a session.
 
     For reverse compatibility.
     """
@@ -121,7 +121,7 @@ def test_filter_permits_no_session():
 
 
 def test_filter_denies():
-    """Confirm filter denies assert passes and fails as expected when specifying a session."""
+    """Confirm filter-denies assert passes and fails as expected when specifying a session."""
     headers = HeaderConstraints(srcIps='1.1.1.1')
     bf = Session()
     with patch.object(bf.q, 'searchFilters',
@@ -149,7 +149,7 @@ def test_filter_denies():
 
 def test_filter_denies_no_session():
     """
-    Confirm filter denies assert passes and fails as expected when not specifying a session.
+    Confirm filter-denies assert passes and fails as expected when not specifying a session.
 
     For reverse compatibility.
     """

--- a/tests/client/test_assert.py
+++ b/tests/client/test_assert.py
@@ -103,8 +103,7 @@ def test_filter_permits_no_session():
     with patch.object(bfq, 'searchFilters', create=True) as mock_search_filters:
         # Test success
         mock_search_filters.return_value = MockQuestion()
-        from pybatfish.client.commands import bf_session
-        assert_filter_permits('filter', headers, session=bf_session)
+        assert_filter_permits('filter', headers)
         mock_search_filters.assert_called_with(filters='filter',
                                                headers=headers,
                                                action='deny')


### PR DESCRIPTION
Update asserts to accept session param where applicable.

Running:
```
assert_filter_permits('filter', headers)
```
behaves as it used to, using the question in `bfq` (and underlying Session `bf_session`) to answer question and perform the assert

Running:
```
assert_filter_permits('filter', headers, session=bf)
```
uses question defined in `bf.q` object (and underlying Session `bf`) to answer question and perform the assert