### PR TITLE
workhelper: better debug timings

### DIFF
--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, print_function
 import datetime
 import json
 import logging
+import string
 import tempfile
 import time
 from typing import Any, Dict, Optional, TYPE_CHECKING  # noqa: F401
@@ -46,7 +47,7 @@ def _batch_desc(json_batch):
         description = "{desc} {completed} / {size}" \
             .format(desc=description, completed=json_batch['completed'],
                     size=json_batch['size'])
-    if not description.endswith((',', '.', '?', '!')):
+    if not description.endswith(string.punctuation):
         description += '.'
     return description
 

--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -47,7 +47,7 @@ def _batch_desc(json_batch):
         description = "{desc} {completed} / {size}" \
             .format(desc=description, completed=json_batch['completed'],
                     size=json_batch['size'])
-    if not description.endswith(string.punctuation):
+    if not description.endswith(tuple(string.punctuation)):
         description += '.'
     return description
 

--- a/pybatfish/client/workhelper.py
+++ b/pybatfish/client/workhelper.py
@@ -41,7 +41,7 @@ MAX_LOG_LENGTH = 64 * 1024
 def _batch_desc(json_batch):
     # type: (Dict) -> str
     """Get a string representation of the Batfish job batch."""
-    description = json_batch.get("description", "").strip()
+    description = json_batch.get("description", "").strip()  # type: str
     if json_batch["size"] > 0:
         description = "{desc} {completed} / {size}" \
             .format(desc=description, completed=json_batch['completed'],
@@ -459,7 +459,7 @@ def _print_work_status_helper(session, work_status, task_details, now_function):
 
         # If true, print the elapsed time since the task started.
         print_elapsed = (
-                (now - task_start_time).total_seconds() > session.elapsed_delay)
+            (now - task_start_time).total_seconds() > session.elapsed_delay)
 
         # Only print info about finished batches in debug mode
         if logger.isEnabledFor(logging.DEBUG):

--- a/tests/client/test_workhelper.py
+++ b/tests/client/test_workhelper.py
@@ -165,7 +165,7 @@ def test_print_workstatus_fresh_task_subtasks(logger, caplog):
     })
     _print_work_status_helper(session, workStatus, taskDetails, nowFunction)
     assert "status: TEST" in caplog.text
-    assert ".... {obtained} Fooing the bar 1 / 2".format(
+    assert ".... {obtained} Fooing the bar 1 / 2.".format(
         obtained=_print_timestamp(
             _parse_timestamp(json.loads(taskDetails)["obtained"]))) \
            in caplog.text
@@ -178,17 +178,17 @@ def test_print_workstatus_old_task(logger, caplog):
                                                    tzinfo=tzinfo)
     workStatus = "TEST"
     taskDetails = json.dumps({
-        "obtained": "2017-12-20 00:00:00 UTC",
+        "obtained": "2016-11-22 10:43:21 UTC",
         "batches": [{
             "completed": 0,
             "description": "Fooing the bar",
             "size": 0,
-            "startDate": "2016-11-22 10:43:21 UTC"
+            "startDate": "2016-11-22 10:43:22 UTC"
         }]
     })
     _print_work_status_helper(session, workStatus, taskDetails, nowFunction)
     assert "status: TEST" in caplog.text
-    assert ".... {obtained} Fooing the bar Elapsed 1y27d13:16:39".format(
+    assert ".... {obtained} Fooing the bar. (1y27d13:16:39 elapsed)".format(
         obtained=_print_timestamp(
             _parse_timestamp(json.loads(taskDetails)["obtained"]))) \
            in caplog.text
@@ -201,17 +201,17 @@ def test_print_workstatus_old_task_subtasks(logger, caplog):
                                                    tzinfo=tzinfo)
     workStatus = "TEST"
     taskDetails = json.dumps({
-        "obtained": "2017-12-20 00:00:00 UTC",
+        "obtained": "2016-11-22 10:43:21 UTC",
         "batches": [{
             "completed": 1,
             "description": "Fooing the bar",
             "size": 2,
-            "startDate": "2016-11-22 10:43:21 UTC"
+            "startDate": "2016-11-22 10:43:22 UTC"
         }]
     })
     _print_work_status_helper(session, workStatus, taskDetails, nowFunction)
     assert "status: TEST" in caplog.text
-    assert ".... {obtained} Fooing the bar 1 / 2 Elapsed 1y27d13:16:39".format(
+    assert ".... {obtained} Fooing the bar 1 / 2. (1y27d13:16:39 elapsed)".format(
         obtained=_print_timestamp(
             _parse_timestamp(json.loads(taskDetails)["obtained"]))) \
            in caplog.text

--- a/tests/client/test_workhelper.py
+++ b/tests/client/test_workhelper.py
@@ -181,7 +181,7 @@ def test_print_workstatus_old_task(logger, caplog):
         "obtained": "2016-11-22 10:43:21 UTC",
         "batches": [{
             "completed": 0,
-            "description": "Fooing the bar",
+            "description": "Fooing the bar.",
             "size": 0,
             "startDate": "2016-11-22 10:43:22 UTC"
         }]


### PR DESCRIPTION
1. `obtainedTime` is not obtained from server, it's obtained from user (aka, task creation). Fix the tests to match reality
2. Since we have the initial start time, print total elapsed time.
3. Minor improvements to output (period).

And fixed up tests.

```
status: TRYINGTOASSIGN
.... no task information
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Begin job.
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Begin job.
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Begin job.
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Parse network configs 16 / 95.
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Parse network configs 46 / 95.
status: CHECKINGSTATUS
.... Mon Apr 15 17:56:14 2019 PDT Parse network configs 84 / 95.
status: CHECKINGSTATUS
.... Mon Apr 15 17:56:14 2019 PDT Serializing 'org.batfish.representation.cisco.CiscoConfiguration' instances to disk 28 / 95.
status: CHECKINGSTATUS
.... Mon Apr 15 17:56:14 2019 PDT Serializing 'org.batfish.representation.cisco.CiscoConfiguration' instances to disk 94 / 95.
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Convert configurations to vendor-independent format 57 / 95. (00:00:05 elapsed)
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Serializing 95 vendor-independent configuration structures for snapshot c4c718a2-af89-4433-a2a6-5066a9131203 20 / 95. (00:00:06 elapsed)
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Serializing 95 vendor-independent configuration structures for snapshot c4c718a2-af89-4433-a2a6-5066a9131203 59 / 95. (00:00:07 elapsed)
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Serializing 95 vendor-independent configuration structures for snapshot c4c718a2-af89-4433-a2a6-5066a9131203 95 / 95. (00:00:08 elapsed)
status: ASSIGNED
.... Mon Apr 15 17:56:14 2019 PDT Deserializing objects of type 'org.batfish.datamodel.Configuration' from files 23 / 95. (00:00:09 elapsed)
```