### PR TITLE
child addressgroups

### DIFF
--- a/pybatfish/datamodel/referencelibrary.py
+++ b/pybatfish/datamodel/referencelibrary.py
@@ -31,15 +31,20 @@ class AddressGroup(DataModelElement):
     :ivar addresses: a list of 'addresses' where each element is a string
         that represents an IP address (e.g., "1.1.1.1") or an address:mask
         (e.g., "1.1.1.1:0.0.0.8").
+    :ivar childGroupNames: a list of names of address groups contained within
+        this address group. The child groups must be within the same reference
+        book. Circular references are allowed.
     """
 
     name = attr.ib(type=str)
     addresses = attr.ib(type=List[str], factory=list)
+    childGroupNames = attr.ib(type=List[str], factory=list)
 
     @classmethod
     def from_dict(cls, json_dict):
         # type: (Dict) -> AddressGroup
-        return AddressGroup(json_dict["name"], json_dict.get("addresses", []))
+        return AddressGroup(json_dict["name"], json_dict.get("addresses", []),
+                            json_dict.get("childGroupNames", []))
 
 
 @attr.s(frozen=True)

--- a/pybatfish/datamodel/referencelibrary.py
+++ b/pybatfish/datamodel/referencelibrary.py
@@ -29,11 +29,13 @@ class AddressGroup(DataModelElement):
 
     :ivar name: The name of the group
     :ivar addresses: a list of 'addresses' where each element is a string
-        that represents an IP address (e.g., "1.1.1.1") or an address:mask
-        (e.g., "1.1.1.1:0.0.0.8").
-    :ivar childGroupNames: a list of names of address groups contained within
-        this address group. The child groups must be within the same reference
-        book. Circular references are allowed.
+        that represents an IP address (e.g., "1.1.1.1"), prefix
+        (e.g., 1.1.1.0/24), or an address:mask (e.g., "1.1.1.1:0.0.0.8").
+    :ivar childGroupNames: a list of names of child groups in this address
+        group. The child groups must exist in the same reference book. Circular
+        descendant relationships between address groups are allowed. The
+        address group is considered to contain all addresses that are directly
+        in it or in any of its descendants.
     """
 
     name = attr.ib(type=str)

--- a/tests/datamodel/test_referencelibrary.py
+++ b/tests/datamodel/test_referencelibrary.py
@@ -18,7 +18,72 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from pybatfish.datamodel.referencelibrary import NodeRolesData, ReferenceLibrary
+from pybatfish.datamodel.referencelibrary import NodeRolesData, \
+    ReferenceLibrary, AddressGroup
+
+
+def test_addressgroup_both_subfields():
+    """Test deserialization for a reference library with address groups."""
+    dict = {
+        "name": "ag1",
+        "addresses": [
+            "1.1.1.1/24",
+            "2.2.2.2"
+        ],
+        "childGroupNames": [
+            "child1",
+            "child2"
+        ]
+    }
+
+    address_group = AddressGroup.from_dict(dict)
+
+    assert len(address_group.addresses) == 2
+    assert len(address_group.childGroupNames) == 2
+
+
+def test_addressgroup_none_subfields():
+    """Test deserialization for a reference library with address groups."""
+    dict = {
+        "name": "ag1"
+    }
+
+    address_group = AddressGroup.from_dict(dict)
+
+    assert len(address_group.addresses) == 0
+    assert len(address_group.childGroupNames) == 0
+
+
+def test_addressgroup_only_addresses():
+    """Test deserialization for a reference library with address groups."""
+    dict = {
+        "name": "ag1",
+        "addresses": [
+            "1.1.1.1/24",
+            "2.2.2.2"
+        ]
+    }
+
+    address_group = AddressGroup.from_dict(dict)
+
+    assert len(address_group.addresses) == 2
+    assert len(address_group.childGroupNames) == 0
+
+
+def test_addressgroup_only_child_groups():
+    """Test deserialization for a reference library with address groups."""
+    dict = {
+        "name": "ag1",
+        "childGroupNames": [
+            "child1",
+            "child2"
+        ]
+    }
+
+    address_group = AddressGroup.from_dict(dict)
+
+    assert len(address_group.addresses) == 0
+    assert len(address_group.childGroupNames) == 2
 
 
 def test_empty_referencelibrary():

--- a/tests/datamodel/test_referencelibrary.py
+++ b/tests/datamodel/test_referencelibrary.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from pybatfish.datamodel.referencelibrary import NodeRolesData, \
-    ReferenceLibrary, AddressGroup
+from pybatfish.datamodel.referencelibrary import AddressGroup, NodeRolesData, \
+    ReferenceLibrary
 
 
 def test_addressgroup_both_subfields():


### PR DESCRIPTION
The following example will work after https://github.com/batfish/batfish/pull/3615
`refbook = ReferenceBook("book1", addressGroups=[{"g1", "addresses": ["1.1.1.1"], childGroupNames=["g2"]}, {"g2", addresses=["2.2.2.2"]}])`  
