### PR TITLE
Pin matplotlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
                 'flake8-docstrings',
                 'flake8-import-order',
                 'jupyter',
+                'matplotlib<3.1.0', # brought in by jupyter; needs to work with py3.5
                 'nbformat',
                 'nbconvert',
                 'pytest>=4.2.0,<5.0.0',


### PR DESCRIPTION
Matplotlib dropped support for py3.5 in v3.1

We should too, eventually, but for now pin matplotlib to before 3.1.0