### PR TITLE
Remove link failures

### DIFF
--- a/jupyter_notebooks/Analyzing the Impact of Failures (and letting loose a Chaos Monkey).ipynb
+++ b/jupyter_notebooks/Analyzing the Impact of Failures (and letting loose a Chaos Monkey).ipynb
@@ -133,7 +133,7 @@
    "source": [
     "In the code, `bf_fork_snapshot` accepts four parameters: `BASE_SNAPSHOT_NAME` indicates the original snapshot name, `FAIL_LONDON_SNAPSHOT_NAME` is the name of the new snapshot, `deactivate_nodes` is a list of nodes that we wish to fail, and `overwrite=True` indicates that we want to reinitialize the snapshot if it already exists. \n",
     "\n",
-    "In addition to `deactivate_nodes`, `bf_fork_snapshot` can also take `deactivate_interfaces` and `deactivate_links` as parameters to simulate interface and link failures. Combining these functions, Batfish allows us to simulate complicated failure scenarios involving interfaces, nodes, and links. For example, `bf_fork_snapshot(BASE_SNAPSHOT_NAME, FAIL_SNAPSHOT_NAME, deactivate_nodes=FAIL_NODES, deactivate_interfaces=FAIL_INTERFACES, overwrite=True))` creates a new snapshot that simulates both node and interface failures."
+    "In addition to `deactivate_nodes`, `bf_fork_snapshot` can also take `deactivate_interfaces` as a parameter to simulate interface failures. Combining these functions, Batfish allows us to simulate complicated failure scenarios involving interfaces and nodes, for example: `bf_fork_snapshot(BASE_SNAPSHOT_NAME, FAIL_SNAPSHOT_NAME, deactivate_nodes=FAIL_NODES, deactivate_interfaces=FAIL_INTERFACES, overwrite=True))`."
    ]
   },
   {
@@ -1369,7 +1369,7 @@
    "source": [
     "## Summary \n",
     "This notebook demonstrates how Batfish help analyze forwarding behavior in network failures. Specifically,\n",
-    "  1. `bf_fork_snapshot` can clone a snapshot from another with deactivated interfaces, links and nodes;\n",
+    "  1. `bf_fork_snapshot` can clone a snapshot from another with deactivated interfaces and nodes;\n",
     "  2. `differentialReachability` can check all forwarding behavior changes for all flows between two snapshots;\n",
     "  3. We can build on top of the basic functions to create more involved analysis such as Chaos Monkey testing."
    ]

--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -27,7 +27,7 @@ from deprecated import deprecated
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
 from pybatfish.datamodel.primitives import (  # noqa: F401
     AutoCompleteSuggestion,
-    Edge, Interface,
+    Interface,
     VariableType)
 from pybatfish.datamodel.referencelibrary import (NodeRoleDimension,
                                                   NodeRolesData, ReferenceBook,
@@ -220,10 +220,9 @@ def bf_extract_answer_summary(answer_dict):
 
 def bf_fork_snapshot(base_name, name=None, overwrite=False,
                      background=False, deactivate_interfaces=None,
-                     deactivate_links=None, deactivate_nodes=None,
-                     restore_interfaces=None, restore_links=None,
+                     deactivate_nodes=None, restore_interfaces=None,
                      restore_nodes=None, add_files=None, extra_args=None):
-    # type: (str, Optional[str], bool, bool, Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Union[str, Dict, None]
+    # type: (str, Optional[str], bool, bool, Optional[List[Interface]], Optional[List[str]], Optional[List[Interface]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Union[str, Dict, None]
     """Copy an existing snapshot and deactivate or reactivate specified interfaces, nodes, and links on the copy.
 
     :param base_name: name of the snapshot to copy
@@ -237,14 +236,10 @@ def bf_fork_snapshot(base_name, name=None, overwrite=False,
     :type background: bool
     :param deactivate_interfaces: list of interfaces to deactivate in new snapshot
     :type deactivate_interfaces: list[Interface]
-    :param deactivate_links: list of links to deactivate in new snapshot
-    :type deactivate_links: list[Edge]
     :param deactivate_nodes: list of names of nodes to deactivate in new snapshot
     :type deactivate_nodes: list[str]
     :param restore_interfaces: list of interfaces to reactivate
     :type restore_interfaces: list[Interface]
-    :param restore_links: list of links to reactivate
-    :type restore_links: list[Edge]
     :param restore_nodes: list of names of nodes to reactivate
     :type restore_nodes: list[str]
     :param add_files: path to zip file or directory containing files to add
@@ -258,10 +253,8 @@ def bf_fork_snapshot(base_name, name=None, overwrite=False,
     return bf_session._fork_snapshot(base_name, name=name, overwrite=overwrite,
                                      background=background,
                                      deactivate_interfaces=deactivate_interfaces,
-                                     deactivate_links=deactivate_links,
                                      deactivate_nodes=deactivate_nodes,
                                      restore_interfaces=restore_interfaces,
-                                     restore_links=restore_links,
                                      restore_nodes=restore_nodes,
                                      add_files=add_files,
                                      extra_args=extra_args)

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -31,7 +31,7 @@ from pybatfish.client._diagnostics import (upload_diagnostics,
                                            warn_on_snapshot_failure)
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
 from pybatfish.client.workhelper import get_work_status
-from pybatfish.datamodel import (Edge, Interface, NodeRoleDimension,
+from pybatfish.datamodel import (Interface, NodeRoleDimension,
                                  NodeRolesData, ReferenceBook,
                                  ReferenceLibrary)
 from pybatfish.datamodel.answer import Answer, TableAnswer  # noqa: F401
@@ -220,11 +220,10 @@ class Session(object):
                                      json_data)
 
     def fork_snapshot(self, base_name, name=None, overwrite=False,
-                      deactivate_interfaces=None, deactivate_links=None,
-                      deactivate_nodes=None, restore_interfaces=None,
-                      restore_links=None, restore_nodes=None, add_files=None,
-                      extra_args=None):
-        # type: (str, Optional[str], bool, Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Optional[str]
+                      deactivate_interfaces=None, deactivate_nodes=None,
+                      restore_interfaces=None, restore_nodes=None,
+                      add_files=None, extra_args=None):
+        # type: (str, Optional[str], bool, Optional[List[Interface]], Optional[List[str]], Optional[List[Interface]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Optional[str]
         """
         Copy an existing snapshot and deactivate or reactivate specified interfaces, nodes, and links on the copy.
 
@@ -237,14 +236,10 @@ class Session(object):
         :type overwrite: bool
         :param deactivate_interfaces: list of interfaces to deactivate in new snapshot
         :type deactivate_interfaces: list[Interface]
-        :param deactivate_links: list of links to deactivate in new snapshot
-        :type deactivate_links: list[Edge]
         :param deactivate_nodes: list of names of nodes to deactivate in new snapshot
         :type deactivate_nodes: list[str]
         :param restore_interfaces: list of interfaces to reactivate
         :type restore_interfaces: list[Interface]
-        :param restore_links: list of links to reactivate
-        :type restore_links: list[Edge]
         :param restore_nodes: list of names of nodes to reactivate
         :type restore_nodes: list[str]
         :param add_files: path to zip file or directory containing files to add
@@ -257,10 +252,8 @@ class Session(object):
         """
         ss_name = self._fork_snapshot(base_name, name=name, overwrite=overwrite,
                                       deactivate_interfaces=deactivate_interfaces,
-                                      deactivate_links=deactivate_links,
                                       deactivate_nodes=deactivate_nodes,
                                       restore_interfaces=restore_interfaces,
-                                      restore_links=restore_links,
                                       restore_nodes=restore_nodes,
                                       add_files=add_files,
                                       extra_args=extra_args)
@@ -270,11 +263,10 @@ class Session(object):
 
     def _fork_snapshot(self, base_name, name=None, overwrite=False,
                        background=False, deactivate_interfaces=None,
-                       deactivate_links=None, deactivate_nodes=None,
-                       restore_interfaces=None, restore_links=None,
+                       deactivate_nodes=None, restore_interfaces=None,
                        restore_nodes=None, add_files=None,
                        extra_args=None):
-        # type: (str, Optional[str], bool, bool, Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[List[Interface]], Optional[List[Edge]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Union[str, Dict, None]
+        # type: (str, Optional[str], bool, bool, Optional[List[Interface]], Optional[List[str]], Optional[List[Interface]], Optional[List[str]], Optional[str], Optional[Dict[str, Any]]) -> Union[str, Dict, None]
         self._check_network()
 
         if name is None:
@@ -307,10 +299,8 @@ class Session(object):
             "snapshotBase": base_name,
             "snapshotNew": name,
             "deactivateInterfaces": deactivate_interfaces,
-            "deactivateLinks": deactivate_links,
             "deactivateNodes": deactivate_nodes,
             "restoreInterfaces": restore_interfaces,
-            "restoreLinks": restore_links,
             "restoreNodes": restore_nodes,
             "zipFile": encoded_file
         }

--- a/tests/integration/test_snapshot_funcs.py
+++ b/tests/integration/test_snapshot_funcs.py
@@ -33,7 +33,7 @@ from pybatfish.client.consts import BfConsts
 from pybatfish.client.extended import (bf_get_snapshot_input_object_text,
                                        bf_get_snapshot_object_text,
                                        bf_put_snapshot_object)
-from pybatfish.datamodel import Edge, Interface
+from pybatfish.datamodel import Interface
 from pybatfish.datamodel.referencelibrary import (NodeRoleDimension,
                                                   NodeRolesData)
 
@@ -149,20 +149,17 @@ def test_fork_snapshot_deactivate(network, example_snapshot):
     restore_name = uuid.uuid4().hex
     node = 'as2border1'
     interface = Interface(hostname='as1border1', interface='GigabitEthernet1/0')
-    link = Edge(node1='as2core1', node1interface='GigabitEthernet1/0',
-                node2='as2border2', node2interface='GigabitEthernet2/0')
 
     bf_set_network(network)
     try:
         # Should succeed with deactivations
         bf_fork_snapshot(base_name=example_snapshot, name=deactivate_name,
                          deactivate_interfaces=[interface],
-                         deactivate_links=[link],
                          deactivate_nodes=[node])
 
         # Should succeed with valid restorations from snapshot with deactivation
         bf_fork_snapshot(base_name=deactivate_name, name=restore_name,
-                         restore_interfaces=[interface], restore_links=[link],
+                         restore_interfaces=[interface],
                          restore_nodes=[node])
     finally:
         bf_delete_snapshot(deactivate_name)


### PR DESCRIPTION
Remove link failures from notebook, tests, and docstrings as that was removed from the backend in https://github.com/batfish/batfish/pull/3840

