### PR TITLE
Bring back doctest, tweak getting started guide

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -82,7 +82,7 @@ cat <<EOF
   - wait
 EOF
 
-###### Integration tests
+###### Integration tests and doctests
 for version in ${PYBATFISH_PYTHON_TEST_VERSIONS[@]}; do
 cat <<EOF
   - label: "Python ${version} integration tests"
@@ -92,6 +92,7 @@ cat <<EOF
       - "java -cp workspace/allinone.jar org.batfish.allinone.Main -runclient false -coordinatorargs '-templatedirs questions -periodassignworkms=5' 2>&1 > workspace/batfish.log &"
       - "pip install -e .[dev] -q"
       - "pytest tests/integration"
+      - "pytest docs pybatfish --doctest-glob='docs/source/*.rst' --doctest-modules"
     plugins:
       - docker#${BATFISH_DOCKER_PLUGIN_VERSION}:
           image: "python:${version}"

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -19,10 +19,12 @@ In these instructions, we assumed that Batfish is running on the same machine as
 >>> load_questions()
 
 4. Upload a network snapshot (you'll see some log messages followed by the
-name of initialized snapshot (prefixed by ``ss_``):
+name of initialized snapshot):
 
->>> bf_init_snapshot('jupyter_notebooks/networks/example') # doctest: +ELLIPSIS
-'ss_...'
+>>> bf_set_network('ex-net')
+'ex-net'
+>>> bf_init_snapshot('jupyter_notebooks/networks/example', name='ex-net-timestamp')
+'ex-net-timestamp'
 
 Here, an example network that is part of the `Pybatfish GitHub repo <https://github.com/batfish/pybatfish>`_ is being uploaded. In general, this location is a folder or a zip containing a network snapshot. See `instructions for packaging snapshots <https://github.com/batfish/batfish/wiki/Packaging-snapshots-for-analysis>`_.
 
@@ -53,7 +55,7 @@ on the dataframe will print the first 5 rows:
 >>> iface_ans = bfq.interfaceProperties(nodes='as1border1', interfaces='GigabitEthernet0/0', properties='all-prefixes').answer()
 >>> iface_ans
                            Interface
-    0  as1border1:GigabitEthernet0/0
+    0  as1border1[GigabitEthernet0/0]
 
 For additional and more in-depth examples, check out the
 `Jupyter Notebooks <https://github.com/batfish/pybatfish/tree/master/jupyter_notebooks>`_.

--- a/pybatfish/client/commands.py
+++ b/pybatfish/client/commands.py
@@ -128,14 +128,14 @@ def bf_auto_complete(completion_type, query, max_suggestions=None):
     """
     Get a list of autocomplete suggestions that match the provided query based on the variable type.
 
-    If completion is not supported for the provied variable type a BatfishException will be raised.
+    If completion is not supported for the provided variable type a BatfishException will be raised.
 
     Usage Example::
 
         >>> from pybatfish.client.commands import bf_auto_complete, bf_set_network
         >>> from pybatfish.datamodel.primitives import AutoCompleteSuggestion, VariableType
         >>> name = bf_set_network()
-        >>> bf_auto_complete(VariableType.ROUTING_PROTOCOL_SPEC, "b")
+        >>> bf_auto_complete(VariableType.ROUTING_PROTOCOL_SPEC, "b") # doctest: +SKIP
         [AutoCompleteSuggestion(description=None, insertion_index=0, is_partial=False, rank=2147483647, text='bgp'),
             AutoCompleteSuggestion(description=None, insertion_index=0, is_partial=False, rank=2147483647, text='ebgp'),
             AutoCompleteSuggestion(description=None, insertion_index=0, is_partial=False, rank=2147483647, text='ibgp')]


### PR DESCRIPTION
1. Bring back doctests, fix up (or skip) whatever is broken
2. Tweak wording in the getting started guide to include `set_network` and naming of the snapshot