### PR TITLE
Add verbose validate_facts option

### DIFF
--- a/pybatfish/client/_facts.py
+++ b/pybatfish/client/_facts.py
@@ -104,10 +104,11 @@ def load_facts(input_directory):
 
 
 def validate_facts(expected, actual, verbose=False):
-    # type: (Dict[Text, Any], Dict[Text, Any]) -> Dict[Text, Any]
+    # type: (Dict[Text, Any], Dict[Text, Any], bool) -> Dict[Text, Any]
     """Return a map of node to non-matching facts based on the difference between the expected and actual facts supplied.
 
-    If the `verbose` flag is set, matching facts are returned in addition-to non-matching facts."""
+    If the `verbose` flag is set, matching facts are returned in addition-to non-matching facts.
+    """
     failures = {}
     expected_facts = expected['nodes']
     actual_facts = actual['nodes']
@@ -291,7 +292,7 @@ def _unencapsulate_facts(facts):
 
 
 def _assert_dict_subset(actual, expected, prefix="", diffs=None, verbose=False):
-    # type: (Dict[Text, Any], Dict[Text, Any], Text, Optional[Dict]) -> Dict[Text, Any]
+    # type: (Dict[Text, Any], Dict[Text, Any], Text, Optional[Dict], bool) -> Dict[Text, Any]
     """Assert that the expected dictionary is a subset of the actual dictionary.
 
     :param actual: the dictionary tested

--- a/pybatfish/client/_facts.py
+++ b/pybatfish/client/_facts.py
@@ -103,9 +103,11 @@ def load_facts(input_directory):
     return out
 
 
-def validate_facts(expected, actual):
+def validate_facts(expected, actual, verbose=False):
     # type: (Dict[Text, Any], Dict[Text, Any]) -> Dict[Text, Any]
-    """Return a map of node to non-matching facts based on the difference between the expected and actual facts supplied."""
+    """Return a map of node to non-matching facts based on the difference between the expected and actual facts supplied.
+
+    If the `verbose` flag is set, matching facts are returned in addition-to non-matching facts."""
     failures = {}
     expected_facts = expected['nodes']
     actual_facts = actual['nodes']
@@ -123,7 +125,8 @@ def validate_facts(expected, actual):
     for node in actual_facts:
         if node in expected_facts:
             res = _assert_dict_subset(actual_facts[node],
-                                      expected_facts[node])
+                                      expected_facts[node],
+                                      verbose=verbose)
             if res:
                 failures[node] = res
     return failures
@@ -287,12 +290,13 @@ def _unencapsulate_facts(facts):
     return facts['nodes'], facts.get('version')
 
 
-def _assert_dict_subset(actual, expected, prefix="", diffs=None):
+def _assert_dict_subset(actual, expected, prefix="", diffs=None, verbose=False):
     # type: (Dict[Text, Any], Dict[Text, Any], Text, Optional[Dict]) -> Dict[Text, Any]
     """Assert that the expected dictionary is a subset of the actual dictionary.
 
     :param actual: the dictionary tested
     :param expected: the expected value of a dictionary
+    :returns: if verbose=`False` returns dictionary of property name to non-matching expected and actual values, if verbose=`True` returns a dictionary of property name to expected and actual values for all checked values
     """
     if diffs is None:
         diffs_out = {}  # type: Dict[Text, Any]
@@ -308,9 +312,9 @@ def _assert_dict_subset(actual, expected, prefix="", diffs=None):
         else:
             if isinstance(expected[k], Mapping):
                 _assert_dict_subset(actual[k], expected[k], key_name + '.',
-                                    diffs_out)
+                                    diffs_out, verbose=verbose)
             else:
-                if expected[k] != actual[k]:
+                if expected[k] != actual[k] or verbose:
                     diffs_out[key_name] = {
                         'expected': expected[k],
                         'actual': actual[k],

--- a/tests/client/test_facts.py
+++ b/tests/client/test_facts.py
@@ -189,14 +189,58 @@ def test_validate_facts_not_matching_data():
                          _encapsulate_nodes_facts(actual, version))
 
     # Result should identify the mismatched value and the missing key
-    assert res['node1'] == {
-        'foo': {
-            'expected': 1,
-            'actual': 0,
+    assert res == {'node1':
+        {
+            'foo': {
+                'expected': 1,
+                'actual': 0,
+            },
+            'baz': {
+                'expected': 1,
+                'key_present': False,
+            }
+        }
+    }
+
+
+def test_validate_facts_verbose():
+    """Test that fact validation returns matching and mismatched facts when running in verbose mode."""
+    expected = {
+        'node1': {'foo': 1, 'bar': 1, 'baz': 1},
+        'node2': {'foo': 2},
+    }
+    actual = {
+        'node1': {'foo': 0, 'bar': 1},  # 'foo' doesn't match expected
+        # also missing 'baz': 1
+        'node2': {'foo': 2},
+        'node3': {'foo': 3},
+    }
+    version = 'version'
+    res = validate_facts(_encapsulate_nodes_facts(expected, version),
+                         _encapsulate_nodes_facts(actual, version),
+                         verbose=True)
+
+    # Verbose validation should return both matching and mismatched facts
+    assert res == {
+        'node1': {
+            'foo': {
+                'expected': 1,
+                'actual': 0,
+            },
+            'bar': {
+                'expected': 1,
+                'actual': 1,
+            },
+            'baz': {
+                'expected': 1,
+                'key_present': False,
+            }
         },
-        'baz': {
-            'expected': 1,
-            'key_present': False,
+        'node2': {
+            'foo': {
+                'expected': 2,
+                'actual': 2,
+            },
         }
     }
 

--- a/tests/client/test_facts.py
+++ b/tests/client/test_facts.py
@@ -189,8 +189,8 @@ def test_validate_facts_not_matching_data():
                          _encapsulate_nodes_facts(actual, version))
 
     # Result should identify the mismatched value and the missing key
-    assert res == {'node1':
-        {
+    assert res == {
+        'node1': {
             'foo': {
                 'expected': 1,
                 'actual': 0,

--- a/tests/client/test_facts.py
+++ b/tests/client/test_facts.py
@@ -204,7 +204,7 @@ def test_validate_facts_not_matching_data():
 
 
 def test_validate_facts_verbose():
-    """Test that fact validation returns matching and mismatched facts when running in verbose mode."""
+    """Test that fact validation returns both matching and mismatched facts when running in verbose mode."""
     expected = {
         'node1': {'foo': 1, 'bar': 1, 'baz': 1},
         'node2': {'foo': 2},


### PR DESCRIPTION
Add option to return all validated properties, not just mismatched properties.  Useful for seeing _all_ properties that were checked.
