### PR TITLE
Support Session entry_points

### DIFF
--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import, print_function
 import base64
 import logging
 import os
-import sys
 import tempfile
 from typing import (Any, Dict, List, Optional,  # noqa: F401
                     Text, Union)
@@ -221,8 +220,6 @@ class Session(object):
     :ivar api_key: Your API key
     """
 
-    BATFISH_SESSION_ENTRY_POINT = 'batfish_session'
-
     def __init__(self, host=Options.coordinator_host,
                  port_v1=Options.coordinator_work_port,
                  port_v2=Options.coordinator_work_v2_port,
@@ -345,13 +342,11 @@ class Session(object):
         # type: () -> Dict[str, Any]
         """Get a dict of possible session types mapping their names to session modules."""
         # Start with this module, which contains the base Pybatfish Session
-        sessions = {
-            'bf': sys.modules[__name__],
+        return {
+            entry_point.name: entry_point.load()
+            for entry_point in
+            pkg_resources.iter_entry_points('batfish_session')
         }
-        for entry_point in pkg_resources.iter_entry_points(
-                cls.BATFISH_SESSION_ENTRY_POINT):
-            sessions[entry_point.name] = entry_point.load()
-        return sessions
 
     @classmethod
     def get(cls, type_='bf', **params):

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -350,7 +350,7 @@ class Session(object):
     @classmethod
     def get(cls, type_='bf', **params):
         # type: (str, **Any) -> Session
-        """Instantiate and return a session object of the specified type with the specified params."""
+        """Instantiate and return a Session object of the specified type with the specified params."""
         sessions = cls.get_session_types()
         session_module = sessions.get(type_)
         if session_module is None:

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -341,7 +341,6 @@ class Session(object):
     def get_session_types(cls):
         # type: () -> Dict[str, Any]
         """Get a dict of possible session types mapping their names to session modules."""
-        # Start with this module, which contains the base Pybatfish Session
         return {
             entry_point.name: entry_point.load()
             for entry_point in

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -342,7 +342,7 @@ class Session(object):
 
     @classmethod
     def get_session_types(cls):
-        # type: (None) -> Dict[str, Any]
+        # type: () -> Dict[str, Any]
         """Get a dict of possible session types mapping their names to session modules."""
         # Start with this module, which contains the base Pybatfish Session
         sessions = {
@@ -354,16 +354,17 @@ class Session(object):
         return sessions
 
     @classmethod
-    def get(cls, type_=None, **params):
+    def get(cls, type_='bf', **params):
         # type: (str, **Any) -> Session
         """Instantiate and return a session object of the specified type with the specified params."""
         sessions = cls.get_session_types()
-        session = sessions.get(type_)
-        if session is None or getattr(session, 'Session') is None:
+        session_module = sessions.get(type_)
+        if session_module is None:
             raise ValueError(
                 "Invalid session type. Specified type '{}' does not match any registered session type: {}".format(
                     type_, sessions.keys()))
-        return session.Session(**params)
+        session = getattr(session_module, 'Session')(**params)  # type: Session
+        return session
 
     def delete_network(self, name):
         # type: (str) -> None

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -19,8 +19,9 @@ import base64
 import logging
 import os
 import tempfile
-from typing import (Any, Dict, List, Optional,  # noqa: F401
-                    Text, Union)
+from typing import (
+    Any, Callable, Dict, List, Optional, Text, Union  # noqa: F401
+)
 
 import pkg_resources
 import six
@@ -339,8 +340,8 @@ class Session(object):
 
     @classmethod
     def get_session_types(cls):
-        # type: () -> Dict[str, Any]
-        """Get a dict of possible session types mapping their names to session modules."""
+        # type: () -> Dict[str, Callable]
+        """Get a dict of possible session types mapping their names to session classes."""
         return {
             entry_point.name: entry_point.load()
             for entry_point in
@@ -357,7 +358,7 @@ class Session(object):
             raise ValueError(
                 "Invalid session type. Specified type '{}' does not match any registered session type: {}".format(
                     type_, sessions.keys()))
-        session = getattr(session_module, 'Session')(**params)  # type: Session
+        session = session_module(**params)  # type: Session
         return session
 
     def delete_network(self, name):

--- a/setup.py
+++ b/setup.py
@@ -159,5 +159,9 @@ setup(
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
-    entry_points={},
+    entry_points={
+        'batfish_session': [
+            'bf = pybatfish.client.session',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         'batfish_session': [
-            'bf = pybatfish.client.session',
+            'bf = pybatfish.client.session:Session',
         ],
     },
 )

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -50,7 +50,7 @@ def test_get_session_types():
 
 
 def test_get_session():
-    """Confirm the correct Session object is built for a specified session type."""
+    """Confirm Session object is built for a specified session type."""
     session_host = 'foobar'
     session = Session.get(type_='bf', load_questions=False, host=session_host)
     # Confirm the session is the correct type
@@ -60,7 +60,7 @@ def test_get_session():
 
 
 def test_get_session_default():
-    """Confirm the correct Session object is built when no type is specified."""
+    """Confirm default Session object is built when no type is specified."""
     session_host = 'foobar'
     session = Session.get(load_questions=False, host=session_host)
     # Confirm the session is the correct type
@@ -70,8 +70,8 @@ def test_get_session_default():
 
 
 def test_get_session_bad():
-    """Confirm the exception is thrown with bad session type passed to Session.get."""
-    bogus_type = 'bogus'
+    """Confirm an exception is thrown when a bad session type passed to Session.get."""
+    bogus_type = 'bogus_session_type'
     with pytest.raises(ValueError) as e:
         Session.get(type_=bogus_type)
     e_msg = str(e.value)

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -35,15 +35,15 @@ class MockEntryPoint(object):
 
 
 def test_get_session_types():
-    """Confirm Session correctly indicates possible session types."""
+    """Test getting possible session types."""
     dummy_session_type = 'dummy'
     dummy_session_module = 'dummy_session_module'
 
+    # Add in a dummy entry point in addition to installed entry_points
     entry_points = (
         [i for i in pkg_resources.iter_entry_points('batfish_session')] +
         [MockEntryPoint(dummy_session_type, dummy_session_module)]
     )
-    # Add in a dummy entry_point
     with patch.object(pkg_resources, 'iter_entry_points',
                       return_value=entry_points):
         session_types = Session.get_session_types()

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -39,9 +39,10 @@ def test_get_session_types():
     dummy_session_type = 'dummy'
     dummy_session_module = 'dummy_session_module'
 
-    entry_points = [i for i in
-                    pkg_resources.iter_entry_points('batfish_session')] + [
-                       MockEntryPoint(dummy_session_type, dummy_session_module)]
+    entry_points = (
+        [i for i in pkg_resources.iter_entry_points('batfish_session')] +
+        [MockEntryPoint(dummy_session_type, dummy_session_module)]
+    )
     # Add in a dummy entry_point
     with patch.object(pkg_resources, 'iter_entry_points',
                       return_value=entry_points):

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+#   Copyright 2018 The Batfish Open Source Project
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pkg_resources
+import pytest
+import six
+
+from pybatfish.client.session import Session
+
+if six.PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
+
+
+class MockEntryPoint(object):
+    def __init__(self, name, module_):
+        self.name = name
+        self.module = module_
+
+    def load(self):
+        return self.module
+
+
+def test_get_session_types():
+    """Confirm Session correctly indicates possible session types."""
+    dummy_session_type = 'dummy'
+    dummy_session_module = 'dummy_session_module'
+
+    # Add in a dummy entry_point
+    with patch.object(pkg_resources, 'iter_entry_points',
+                      return_value=[MockEntryPoint(dummy_session_type,
+                                                   dummy_session_module)]):
+        session_types = Session.get_session_types()
+
+    # Confirm both the base and our mock types show up
+    assert set(session_types.keys()) == {'bf', dummy_session_type}
+
+
+def test_get_session():
+    """Confirm the correct Session object is built for a specified session type."""
+    session_host = 'foobar'
+    session = Session.get(type_='bf', load_questions=False, host=session_host)
+    # Confirm the session is the correct type
+    assert isinstance(session, Session)
+    # Confirm params were passed through
+    assert session.host == session_host
+
+
+def test_get_session_default():
+    """Confirm the correct Session object is built when no type is specified."""
+    session_host = 'foobar'
+    session = Session.get(load_questions=False, host=session_host)
+    # Confirm the session is the correct type
+    assert isinstance(session, Session)
+    # Confirm params were passed through
+    assert session.host == session_host
+
+
+def test_get_session_bad():
+    """Confirm the exception is thrown with bad session type passed to Session.get."""
+    bogus_type = 'bogus'
+    with pytest.raises(ValueError) as e:
+        Session.get(type_=bogus_type)
+    e_msg = str(e.value)
+    assert 'Invalid session type' in e_msg
+    assert "type '{}' does not match".format(bogus_type) in e_msg

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -73,7 +73,7 @@ def test_get_session_default():
 
 
 def test_get_session_bad():
-    """Confirm an exception is thrown when a bad session type passed to Session.get."""
+    """Confirm an exception is thrown when a bad session type passed in."""
     bogus_type = 'bogus_session_type'
     with pytest.raises(ValueError) as e:
         Session.get(type_=bogus_type)

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -39,14 +39,17 @@ def test_get_session_types():
     dummy_session_type = 'dummy'
     dummy_session_module = 'dummy_session_module'
 
+    entry_points = [i for i in
+                    pkg_resources.iter_entry_points('batfish_session')] + [
+                       MockEntryPoint(dummy_session_type, dummy_session_module)]
     # Add in a dummy entry_point
     with patch.object(pkg_resources, 'iter_entry_points',
-                      return_value=[MockEntryPoint(dummy_session_type,
-                                                   dummy_session_module)]):
+                      return_value=entry_points):
         session_types = Session.get_session_types()
 
     # Confirm both the base and our mock types show up
-    assert set(session_types.keys()) == {'bf', dummy_session_type}
+    assert 'bf' in session_types.keys()
+    assert dummy_session_type in session_types.keys()
 
 
 def test_get_session():


### PR DESCRIPTION
Support recognizing `batfish_session` `entry_points` specified in `setup.py`

Also allow user to build a `Session` object by specifying the type and object params, e.g.: `Session.get('bf', load_questions=False)`