### PR TITLE
Pin pydocstyle

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -23,7 +23,7 @@ cat <<EOF
     command:
       - "python3 -m virtualenv .venv"
       - ". .venv/bin/activate"
-      - "python3 -m pip install flake8 flake8-docstrings flake8-import-order"
+      - "python3 -m pip install flake8 'pydocstyle<4.0.0' flake8-docstrings flake8-import-order"
       - "flake8 pybatfish tests"
     plugins:
       - docker#${BATFISH_DOCKER_PLUGIN_VERSION}:

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
                 'matplotlib<3.1.0',
                 'nbformat',
                 'nbconvert',
+                'pydocstyle<4.0.0',
                 'pytest>=4.2.0,<5.0.0',
                 'pytz',
                 'requests_mock',


### PR DESCRIPTION
4.0.0 dropped support for legacy python

@dhalperi @sfraint We **need** to start letting people know we're going to drop support for py2, in our documentation and examples, otherwise we're digging ourselves into a hole where all the libraries we use are going to be outdated.