### PR TITLE
Tiny Jupyter notebook fixes

### DIFF
--- a/jupyter_notebooks/Analyzing ACLs and Firewall Rules.ipynb
+++ b/jupyter_notebooks/Analyzing ACLs and Firewall Rules.ipynb
@@ -677,7 +677,7 @@
    "source": [
     "# Find unreachable lines in filters of rtr-with-acl\n",
     "aclAns = bfq.filterLineReachability(nodes=\"rtr-with-acl\").answer()\n",
-    "show(aclAns.frame())"
+    "show(aclAns.frame().sort_values(by=\"Unreachable_Line\"))"
    ]
   },
   {

--- a/jupyter_notebooks/Analyzing ACLs and Firewall Rules.ipynb
+++ b/jupyter_notebooks/Analyzing ACLs and Firewall Rules.ipynb
@@ -529,11 +529,11 @@
    ],
    "source": [
     "# Check if any non-NFS, TCP flow can go from one zone to another\n",
-    "non_nsf_tcp_traffic = HeaderConstraints(srcIps=\"101.164.101.231\",\n",
+    "non_nfs_tcp_traffic = HeaderConstraints(srcIps=\"101.164.101.231\",\n",
     "                                        dstIps=\"101.164.9.0/24\",\n",
     "                                        ipProtocols=[\"tcp\"],\n",
     "                                        dstPorts=\"!2049\")  # exclude NFS port (2049)\n",
-    "answer = bfq.searchFilters(headers=non_nsf_tcp_traffic,\n",
+    "answer = bfq.searchFilters(headers=non_nfs_tcp_traffic,\n",
     "                           startLocation=\"@enter(firewall[GigabitEthernet0/0/2])\",\n",
     "                           filters=\"@out(GigabitEthernet0/0/3)\",\n",
     "                           action=\"permit\").answer()\n",


### PR DESCRIPTION
Address several small nits in the "Analyzing ACLs and Firewall Rules" notebook:
- Typo when referring to NFS.
- Sort output of `filterLineReachability` question so it is as described in the text; without this change, the order is wrong.