### PR TITLE
Update bgp status spec and add more assert tests

### DIFF
--- a/pybatfish/client/asserts.py
+++ b/pybatfish/client/asserts.py
@@ -51,7 +51,7 @@ __all__ = [
     'assert_zero_results',
 ]
 
-_INCOMPATIBLE_BGP_SESSION_STATUS_REGEX = '/(?!UNIQUE_MATCH)(?!DYNAMIC_MATCH)(?!UNKNOWN_REMOTE).*/'
+_INCOMPATIBLE_BGP_SESSION_STATUS_REGEX = '/^(?!UNIQUE_MATCH)(?!DYNAMIC_MATCH)(?!UNKNOWN_REMOTE).*$/'
 
 
 def assert_zero_results(answer, soft=False):

--- a/pybatfish/client/asserts.py
+++ b/pybatfish/client/asserts.py
@@ -51,6 +51,10 @@ __all__ = [
     'assert_zero_results',
 ]
 
+# Following regex is matching anything other than `UNIQUE_MATCH`, `DYNAMIC_MATCH`, or `UNKNOWN_REMOTE`
+# ?! groups are negative lookaheads, meaning don't match the specified text but also don't consume the checked characters
+# ^ and $ anchors are needed to prevent substring matching in Batfish
+# e.g. within the string `UNKNOWN_REMOTE`, technically this regex matches any substring starting after position 0 (e.g. `NKNOWN_REMOTE`)
 _INCOMPATIBLE_BGP_SESSION_STATUS_REGEX = '/^(?!UNIQUE_MATCH)(?!DYNAMIC_MATCH)(?!UNKNOWN_REMOTE).*$/'
 
 

--- a/tests/integration/snapshots/asserts_fail/configs/node.cfg
+++ b/tests/integration/snapshots/asserts_fail/configs/node.cfg
@@ -12,6 +12,8 @@ interface GigabitEthernet0/0
 !
 interface GigabitEthernet1/0
  ip address 2.0.1.1 255.255.255.0
+ ! Undefined ACL
+ ip access-group 102 out
 !
 interface GigabitEthernet2/0
  ip address 10.13.22.1 255.255.255.0
@@ -19,24 +21,24 @@ interface GigabitEthernet2/0
 interface GigabitEthernet3/0
  ip address 10.14.22.1 255.255.255.0
 !
-
+router ospf 1
+ network 0.0.0.0 0.0.0.0 area 0
+!
 access-list 101 permit ip host 1.0.1.0 host 8.8.8.8
+! Unreachable line, blocked by the first line in this ACL
+access-list 101 deny ip host 1.0.1.0 host 8.8.8.8
 access-list 101 permit ip host 2.0.1.0 host 1.0.1.0
 access-list 101 deny ip any any
 !
-! BGP sessions have unknown remotes
-router bgp 1
- bgp router-id 1.2.2.2
- neighbor as3 peer-group
- neighbor as3 remote-as 3
- neighbor as4 peer-group
- neighbor as4 remote-as 4
- neighbor 10.13.22.3 peer-group as3
- neighbor 10.14.22.4 peer-group as4
+router bgp 2
+ bgp router-id 1.1.1.1
+ bgp log-neighbor-changes
+ neighbor as2 peer-group
+ neighbor as2 remote-as 2
+ neighbor 2.1.1.1 peer-group as2
+ neighbor 2.1.1.1 update-source Loopback0
  !
  address-family ipv4
-  network 1.0.1.0 mask 255.255.255.0
-  neighbor 10.13.22.3 activate
-  neighbor 10.14.22.4 activate
+  neighbor 2.1.1.1 activate
  exit-address-family
 !

--- a/tests/integration/snapshots/asserts_fail/configs/remote_node.cfg
+++ b/tests/integration/snapshots/asserts_fail/configs/remote_node.cfg
@@ -1,0 +1,36 @@
+!
+version 15.2
+!
+hostname remote_node
+!
+interface Loopback0
+ ip address 2.1.1.1 255.255.255.255
+!
+interface GigabitEthernet0/0
+ ip address 1.0.1.2 255.255.255.0
+!
+interface GigabitEthernet1/0
+ ip address 2.0.1.2 255.255.255.0
+!
+interface GigabitEthernet2/0
+ ip address 10.13.22.2 255.255.255.0
+!
+interface GigabitEthernet3/0
+ ip address 10.14.22.2 255.255.255.0
+!
+router ospf 1
+ network 0.0.0.0 0.0.0.0 area 0
+!
+router bgp 2
+ bgp router-id 2.1.1.1
+ bgp log-neighbor-changes
+ neighbor as2 peer-group
+ neighbor as2 remote-as 2
+ neighbor 1.1.1.1 peer-group as2
+ ! Cause BGP session to be incompatible (local IP unknown statically)
+ ! neighbor 1.1.1.1 update-source Loopback0
+ !
+ address-family ipv4
+  neighbor 1.1.1.1 activate
+ exit-address-family
+!

--- a/tests/integration/test_asserts.py
+++ b/tests/integration/test_asserts.py
@@ -18,15 +18,25 @@ import pytest
 
 from pybatfish.client.session import Session
 from pybatfish.datamodel import HeaderConstraints
+from pybatfish.exception import BatfishAssertException
 
 _this_dir = abspath(dirname(realpath(__file__)))
 
 
-# Just use a single session for all assertion tests
+# Just use a single session and snapshot for all passing assertion tests
 @pytest.fixture(scope='module')
-def session():
+def session_pass():
     s = Session()
     name = s.init_snapshot(join(_this_dir, 'snapshots', 'asserts'))
+    yield s
+    s.delete_snapshot(name)
+
+
+# Just use a single session and snapshot for all failing assertion tests
+@pytest.fixture(scope='module')
+def session_fail():
+    s = Session()
+    name = s.init_snapshot(join(_this_dir, 'snapshots', 'asserts_fail'))
     yield s
     s.delete_snapshot(name)
 
@@ -75,7 +85,58 @@ def session():
      {}
      ),
 ])
-def test_asserts_run(session, assert_func, params):
+def test_asserts_pass(session_pass, assert_func, params):
     """Test that each assertion runs successfully."""
     # Assertion should run without errors and return True (passing assert)
-    assert getattr(session.asserts, assert_func)(**params)
+    assert getattr(session_pass.asserts, assert_func)(**params)
+
+
+@pytest.mark.parametrize('assert_func, params', [
+    ('assert_filter_denies',
+     {
+         'filters': '/101/',
+         'headers': HeaderConstraints(srcIps='1.0.1.0', dstIps='8.8.8.8'),
+         'startLocation': '@enter(node[GigabitEthernet1/0])',
+     }
+     ),
+    ('assert_filter_has_no_unreachable_lines',
+     {
+         'filters': '/101/',
+     }
+     ),
+    ('assert_filter_permits',
+     {
+         'filters': '/101/',
+         'headers': HeaderConstraints(srcIps='12.34.56.78'),
+         'startLocation': '@enter(node[GigabitEthernet1/0])',
+     }
+     ),
+    ('assert_flows_fail',
+     {
+         'startLocation': '@enter(node[GigabitEthernet1/0])',
+         'headers': HeaderConstraints(srcIps='2.0.1.0', dstIps='1.0.1.0',
+                                      ipProtocols=['TCP']),
+     }
+     ),
+    ('assert_flows_succeed',
+     {
+         'startLocation': '@enter(node[GigabitEthernet1/0])',
+         'headers': HeaderConstraints(srcIps='12.34.56.78', dstIps='1.0.1.0',
+                                      ipProtocols=['TCP']),
+     }
+     ),
+    ('assert_no_incompatible_bgp_sessions',
+     {}
+     ),
+    ('assert_no_unestablished_bgp_sessions',
+     {}
+     ),
+    ('assert_no_undefined_references',
+     {}
+     ),
+])
+def test_asserts_fail(session_fail, assert_func, params):
+    """Test that each assertion fails as expected."""
+    # Assertion should fail and raise a BatfishAssertException
+    with pytest.raises(BatfishAssertException):
+        getattr(session_fail.asserts, assert_func)(**params)


### PR DESCRIPTION
Update `bgp` status spec to work with new substring semantics in `Batfish` (previous PR just fixed the regex syntax, not it's correctness).

Flesh out more `pybatfish.client.asserts` tests:
* Add BGP sessions with `unknown remote` to passing test config (these should be filtered out by default status spec)
* Add some e2e tests for failing asserts
