### PR TITLE
Use new version API

### DIFF
--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -343,6 +343,12 @@ def get_work_log(session, snapshot, work_id):
     return _get(session, url_tail, dict()).text
 
 
+def get_component_versions(session):
+    # type: (Session) -> Dict[Text, Text]
+    """Get a dictionary of backend components (e.g. Batfish, Z3) and their versions."""
+    return _get_dict(session, "/version")
+
+
 def put_network_object(session, key, data):
     # type: (Session, str, Any) -> None
     """Put data as extended object with given key for the current network."""

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -344,7 +344,7 @@ def get_work_log(session, snapshot, work_id):
 
 
 def get_component_versions(session):
-    # type: (Session) -> Dict[Text, Text]
+    # type: (Session) -> Dict[str, Any]
     """Get a dictionary of backend components (e.g. Batfish, Z3) and their versions."""
     return _get_dict(session, "/version")
 

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -683,6 +683,7 @@ class Session(object):
         return get_work_status(work_item, self)
 
     def get_component_versions(self):
+        # type: () -> Dict[str, Any]
         """Get a dictionary of backend components (e.g. Batfish, Z3) and their versions."""
         return get_component_versions(self)
 

--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -42,6 +42,7 @@ from pybatfish.client.asserts import (
     assert_no_unestablished_bgp_sessions,
 )
 from pybatfish.client.consts import CoordConsts, WorkStatusCode
+from pybatfish.client.restv2helper import get_component_versions
 from pybatfish.client.workhelper import get_work_status
 from pybatfish.datamodel import (
     HeaderConstraints, Interface, NodeRoleDimension, NodeRolesData,
@@ -680,6 +681,10 @@ class Session(object):
     def get_work_status(self, work_item):
         """Get the status for the specified work item."""
         return get_work_status(work_item, self)
+
+    def get_component_versions(self):
+        """Get a dictionary of backend components (e.g. Batfish, Z3) and their versions."""
+        return get_component_versions(self)
 
     def init_snapshot(self, upload, name=None, overwrite=False,
                       extra_args=None):

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+#   Copyright 2018 The Batfish Open Source Project
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import pytest
+
+from pybatfish.client.session import Session
+
+
+@pytest.fixture()
+def session():
+    return Session()
+
+
+def test_get_component_versions(session):
+    """Confirm component versions can be fetched from the service."""
+    # Make sure Batfish is one of the versioned components
+    assert 'Batfish' in session.get_component_versions()


### PR DESCRIPTION
Use new version API for fetching component version (e.g. Batfish, Z3) and add simple integration test
