### PR TITLE
Improve session error message

### DIFF
--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -373,7 +373,7 @@ class Session(object):
         if session_module is None:
             raise ValueError(
                 "Invalid session type. Specified type '{}' does not match any registered session type: {}".format(
-                    type_, sessions.keys()))
+                    type_, set(sessions.keys())))
         session = session_module(**params)  # type: Session
         return session
 


### PR DESCRIPTION
Make invalid session type error a little prettier.

When an invalid session type is specified, the error was:
```
ValueError: Invalid session type.
Specified type 'bogus' does not match any registered session type: dict_keys(['bf'])
```
with this PR it is:
```
ValueError: Invalid session type.
Specified type 'bogus' does not match any registered session type: {'bf'}
```
