### PR TITLE
Hide old flow classes from __all__

### DIFF
--- a/pybatfish/datamodel/flow.py
+++ b/pybatfish/datamodel/flow.py
@@ -26,8 +26,6 @@ __all__ = [
     'ExitOutputIfaceStepDetail',
     'FilterStepDetail',
     'Flow',
-    'FlowTrace',
-    'FlowTraceHop',
     'HeaderConstraints',
     'Hop',
     'InboundStepDetail',


### PR DESCRIPTION
Simplified documentation, less confusion.
Only used in _really_ old questions (if any)