### PR TITLE
Update validated OSPF facts

### DIFF
--- a/tests/integration/facts/expected_facts/basic.yml
+++ b/tests/integration/facts/expected_facts/basic.yml
@@ -120,7 +120,6 @@ nodes:
         OSPF_Cost: null
         OSPF_Enabled: false
         OSPF_Passive: false
-        OSPF_Point_To_Point: false
         Outgoing_Filter_Name: null
         PBR_Policy_Name: null
         Primary_Address: null
@@ -162,7 +161,6 @@ nodes:
         OSPF_Cost: 1
         OSPF_Enabled: true
         OSPF_Passive: false
-        OSPF_Point_To_Point: false
         Outgoing_Filter_Name: null
         PBR_Policy_Name: null
         Primary_Address: 1.0.1.1/24
@@ -204,7 +202,6 @@ nodes:
         OSPF_Cost: null
         OSPF_Enabled: false
         OSPF_Passive: false
-        OSPF_Point_To_Point: false
         Outgoing_Filter_Name: null
         PBR_Policy_Name: null
         Primary_Address: 10.12.11.1/24
@@ -246,7 +243,6 @@ nodes:
         OSPF_Cost: 1
         OSPF_Enabled: true
         OSPF_Passive: true
-        OSPF_Point_To_Point: false
         Outgoing_Filter_Name: null
         PBR_Policy_Name: null
         Primary_Address: 1.1.1.1/32

--- a/tests/integration/test_facts.py
+++ b/tests/integration/test_facts.py
@@ -16,7 +16,7 @@ from os.path import abspath, dirname, join, pardir, realpath
 
 import pytest
 
-from pybatfish.client._facts import load_facts
+from pybatfish.client._facts import load_facts, validate_facts
 from pybatfish.client.session import Session
 
 _this_dir = abspath(dirname(realpath(__file__)))
@@ -40,8 +40,10 @@ def test_extract_facts(tmpdir, session):
     written_facts = load_facts(str(out_dir))
     expected_facts = load_facts(join(_this_dir, 'facts', 'expected_facts'))
 
-    assert extracted_facts == expected_facts, 'Extracted facts match expected facts'
-    assert written_facts == expected_facts, 'Facts written to disk match expected facts'
+    assert validate_facts(expected_facts,
+                          extracted_facts) == {}, 'Extracted facts match expected facts'
+    assert validate_facts(expected_facts,
+                          written_facts) == {}, 'Written facts match expected facts'
 
 
 def test_validate_facts_matching(session):


### PR DESCRIPTION
Remove `point_to_point` bool from expected facts (see https://github.com/batfish/batfish/pull/4481) and make failed test output more human-readable
