### PR TITLE
Add support for OSPF session status spec param type

### DIFF
--- a/pybatfish/datamodel/primitives.py
+++ b/pybatfish/datamodel/primitives.py
@@ -139,6 +139,7 @@ class VariableType(str, Enum):
     NODE_SPEC = "nodeSpec"  #: node specifier
     OSPF_INTERFACE_PROPERTY_SPEC = "ospfInterfacePropertySpec"  #: ospf interface properties
     OSPF_PROCESS_PROPERTY_SPEC = "ospfProcessPropertySpec"  #: ospf process properties
+    OSPF_SESSION_STATUS_SPEC = "ospfSessionStatusSpec"  #: ospf session statuses
     PATH_CONSTRAINT = "pathConstraint"  #: path constraints
     PREFIX = "prefix"  #: prefixes
     PREFIX_RANGE = "prefixRange"  #: prefix ranges

--- a/pybatfish/question/question.py
+++ b/pybatfish/question/question.py
@@ -779,6 +779,7 @@ def _validateType(value, expectedType):
         VariableType.NODE_SPEC,
         VariableType.OSPF_INTERFACE_PROPERTY_SPEC,
         VariableType.OSPF_PROCESS_PROPERTY_SPEC,
+        VariableType.OSPF_SESSION_STATUS_SPEC,
         VariableType.REFERENCE_BOOK_NAME,
         VariableType.ROUTING_PROTOCOL_SPEC,
         VariableType.STRUCTURE_NAME,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ COMPLETION_TYPES = [
     VariableType.NODE_SPEC,
     VariableType.OSPF_INTERFACE_PROPERTY_SPEC,
     VariableType.OSPF_PROCESS_PROPERTY_SPEC,
+    VariableType.OSPF_SESSION_STATUS_SPEC,
     VariableType.PREFIX,
     VariableType.PROTOCOL,
     VariableType.REFERENCE_BOOK_NAME,


### PR DESCRIPTION
OSPF session status spec was added in https://github.com/batfish/batfish/pull/4694, update param validation to support this.
