### PR TITLE
Update extended method types

### DIFF
--- a/pybatfish/client/extended.py
+++ b/pybatfish/client/extended.py
@@ -60,7 +60,7 @@ def bf_get_snapshot_input_object_stream(key, snapshot=None):
 
 
 def bf_get_snapshot_input_object_text(key, encoding='utf-8', snapshot=None):
-    # type: (Text, Text, Optional[Text]) -> str
+    # type: (Text, Text, Optional[Text]) -> Text
     """Returns the text content of the snapshot input object with specified key."""
     with bf_get_snapshot_input_object_stream(key, snapshot) as stream:
         text = stream.read().decode(encoding)
@@ -74,7 +74,7 @@ def bf_get_snapshot_object_stream(key, snapshot=None):
 
 
 def bf_get_snapshot_object_text(key, encoding='utf-8', snapshot=None):
-    # type: (Text, Text, Optional[Text]) -> str
+    # type: (Text, Text, Optional[Text]) -> Text
     """Returns the text content of the snapshot object with specified key."""
     with bf_get_snapshot_object_stream(key, snapshot) as stream:
         text = stream.read().decode(encoding)

--- a/pybatfish/client/extended.py
+++ b/pybatfish/client/extended.py
@@ -34,19 +34,19 @@ __all__ = ['bf_delete_network_object',
 
 
 def bf_delete_network_object(key):
-    # type: (str) -> None
+    # type: (Text) -> None
     """Deletes the network object with specified key."""
     return restv2helper.delete_network_object(bf_session, key)
 
 
 def bf_get_network_object_stream(key):
-    # type: (str) -> Any
+    # type: (Text) -> Any
     """Returns a binary stream of the content of the network object with specified key."""
     return restv2helper.get_network_object(bf_session, key)
 
 
 def bf_get_network_object_text(key, encoding='utf-8'):
-    # type: (str, str) -> str
+    # type: (Text, Text) -> str
     """Returns the text content of the network object with specified key."""
     with bf_get_network_object_stream(key) as stream:
         text = stream.read().decode(encoding)
@@ -74,7 +74,7 @@ def bf_get_snapshot_object_stream(key, snapshot=None):
 
 
 def bf_get_snapshot_object_text(key, encoding='utf-8', snapshot=None):
-    # type: (str, str, Optional[str]) -> str
+    # type: (Text, Text, Optional[Text]) -> str
     """Returns the text content of the snapshot object with specified key."""
     with bf_get_snapshot_object_stream(key, snapshot) as stream:
         text = stream.read().decode(encoding)
@@ -82,7 +82,7 @@ def bf_get_snapshot_object_text(key, encoding='utf-8', snapshot=None):
 
 
 def bf_put_network_object(key, data):
-    # type: (str, Any) -> None
+    # type: (Text, Any) -> None
     """Puts data as the network object with specified key."""
     restv2helper.put_network_object(bf_session, key, data)
 

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -126,7 +126,7 @@ def fork_snapshot(session, obj):
 
 
 def delete_network_object(session, key):
-    # type: (Session, str) -> None
+    # type: (Session, Text) -> None
     """Deletes extended object with given key for the current network."""
     url_tail = "/{}/{}/{}".format(CoordConstsV2.RSC_NETWORKS, session.network,
                                   CoordConstsV2.RSC_OBJECTS)
@@ -197,7 +197,7 @@ def get_network(session, network):
 
 
 def get_network_object(session, key):
-    # type: (Session, str) -> Any
+    # type: (Session, Text) -> Any
     """Gets extended object with given key for the current network."""
     url_tail = "/{}/{}/{}".format(CoordConstsV2.RSC_NETWORKS, session.network,
                                   CoordConstsV2.RSC_OBJECTS)
@@ -350,7 +350,7 @@ def get_component_versions(session):
 
 
 def put_network_object(session, key, data):
-    # type: (Session, str, Any) -> None
+    # type: (Session, Text, Any) -> None
     """Put data as extended object with given key for the current network."""
     url_tail = "/{}/{}/{}".format(CoordConstsV2.RSC_NETWORKS, session.network,
                                   CoordConstsV2.RSC_OBJECTS)


### PR DESCRIPTION
Update types used in `extended` functions, prefer `Text` over `str` (finishing changed started in https://github.com/batfish/pybatfish/pull/425).
