### PR TITLE
Remove Capirca/absl-py workaround

### DIFF
--- a/pybatfish/client/capirca.py
+++ b/pybatfish/client/capirca.py
@@ -35,7 +35,7 @@ from pybatfish.datamodel import AddressGroup, ReferenceBook
 if TYPE_CHECKING:
     from pybatfish.client.session import Session  # noqa: F401
 
-__all__ = ["create_reference_book", "init_snapshot_from_acl"]
+__all__ = ["create_reference_book"]
 
 
 def _item_to_python_repr(item, definitions):

--- a/pybatfish/client/capirca.py
+++ b/pybatfish/client/capirca.py
@@ -30,31 +30,12 @@ except ImportError:
         'Capirca must be installed to use the Pybatfish Capirca extensions')
     raise
 
-try:
-    # Capirca uses Google's abseil-py library, which uses a Google-specific
-    # wrapper for logging. That wrapper will write a warning to sys.stderr if
-    # the Google command-line flags library has not been initialized.
-    #
-    # https://github.com/abseil/abseil-py/blob/pypi-v0.7.1/absl/logging/__init__.py#L819-L825
-    #
-    # This is not right behavior for Python code that is invoked outside of a
-    # Google-authored main program. Use knowledge of abseil-py to disable that
-    # warning; ignore and continue if something goes wrong.
-    import absl.logging
-
-    # https://github.com/abseil/abseil-py/issues/99
-    logging.root.removeHandler(absl.logging._absl_handler)
-    # https://github.com/abseil/abseil-py/issues/102
-    absl.logging._warn_preinit_stderr = False
-except Exception:
-    pass
-
 from pybatfish.datamodel import AddressGroup, ReferenceBook
 
 if TYPE_CHECKING:
     from pybatfish.client.session import Session  # noqa: F401
 
-__all__ = ["create_reference_book"]
+__all__ = ["create_reference_book", "init_snapshot_from_acl"]
 
 
 def _item_to_python_repr(item, definitions):

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ import pybatfish
 here = path.abspath(path.dirname(__file__))
 PY2 = version_info[0] == 2
 
+# Capirca dependencies
+CAPIRCA_DEPS = ['capirca', 'absl-py>=0.8.0'] + (['ipaddress'] if PY2 else [])
+
 # Get the long description from the README file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -120,10 +123,9 @@ setup(
     # for example:
     # $ pip install -e .[dev]
     extras_require={
-        'capirca': ['capirca'] + (['ipaddress'] if PY2 else []),
+        'capirca': CAPIRCA_DEPS,
         'dev': ['autoflake',
                 'autopep8',
-                'capirca',
                 'check-manifest',
                 'coverage',
                 'flake8',
@@ -143,7 +145,8 @@ setup(
                 'sphinx>=1.8.0',
                 'sphinx_rtd_theme',
                 ] + \
-               (['ipaddress', 'mock'] if PY2 else ['mypy']),
+               CAPIRCA_DEPS + \
+               (['mock'] if PY2 else ['mypy']),
     },
 
     # List pytest requirements for running unit tests


### PR DESCRIPTION
In the latest release of absl-py common library, Google fixed the logging
mess. Force a minimum version of that library and remove the hack.

https://github.com/abseil/abseil-py/issues/99