### PR TITLE
Update collections import

### DIFF
--- a/pybatfish/client/_facts.py
+++ b/pybatfish/client/_facts.py
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import os
-from collections import Mapping
+from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, Dict, Optional, TYPE_CHECKING, Text, Tuple  # noqa: F401
 

--- a/pybatfish/util.py
+++ b/pybatfish/util.py
@@ -21,7 +21,7 @@ import string
 import tempfile
 import uuid
 import zipfile
-from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any, IO, Sized, Union  # noqa: F401
 
 import simplejson


### PR DESCRIPTION
Since we're no longer supporting `Python2`, import from `collections` using `Python3`-preferred, non-deprecated method

Avoids the `DeprecationWarning`:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
