### PR TITLE
Diagnostics: do not clobber proxies defined in environment

### DIFF
--- a/pybatfish/client/_diagnostics.py
+++ b/pybatfish/client/_diagnostics.py
@@ -146,7 +146,7 @@ def upload_diagnostics(
             upload_dest,
             tmp_dir_anon,
             headers={"x-amz-acl": "bucket-owner-full-control"},
-            proxies={"https": proxy},
+            proxies={"https": proxy} if proxy is not None else None,
         )
         logger.debug("Uploaded files to: {}".format(upload_dest))
     finally:


### PR DESCRIPTION
As @eidorb correctly points out in #503, previous fix erroneously overrides proxy env vars if they are set.

This fixes it up: propagate proxy dict to callees only if the proxy URL was explicitly set. Otherwise `requests` will pick up the `HTTPS_PROXY` var.

@dhalperi manual testing procedure https://docs.google.com/document/d/1WbjcjjvCR6A4iB06CjZElfro0rlgEBgAzjfR478ktxQ/edit