### PR TITLE
Fix role tests

### DIFF
--- a/tests/integration/test_network_funcs.py
+++ b/tests/integration/test_network_funcs.py
@@ -46,6 +46,7 @@ from pybatfish.datamodel.referencelibrary import (
     RoleDimensionMapping,
     RoleMapping,
 )
+from tests.common_util import requires_bf
 from tests.conftest import COMPLETION_TYPES
 
 _this_dir = abspath(dirname(realpath(__file__)))
@@ -88,6 +89,7 @@ def test_list_networks():
         bf_delete_network(name)
 
 
+@requires_bf("2019.12.07")
 def test_add_node_role_dimension():
     try:
         network_name = "n1"
@@ -135,6 +137,7 @@ def test_get_node_role_dimension():
         bf_delete_network(network_name)
 
 
+@requires_bf("2019.12.07")
 def test_delete_node_role_dimension():
     try:
         network_name = "n1"
@@ -157,6 +160,7 @@ def test_delete_node_role_dimension():
         bf_delete_network(network_name)
 
 
+@requires_bf("2019.12.07")
 def test_put_node_role_dimension():
     try:
         network_name = "n1"

--- a/tests/integration/test_network_funcs.py
+++ b/tests/integration/test_network_funcs.py
@@ -90,7 +90,7 @@ def test_list_networks():
 
 
 @requires_bf("2019.12.07")
-def test_add_node_role_dimension():
+def test_add_node_role_dimension(session):
     try:
         network_name = "n1"
         bf_set_network(network_name)
@@ -138,7 +138,7 @@ def test_get_node_role_dimension():
 
 
 @requires_bf("2019.12.07")
-def test_delete_node_role_dimension():
+def test_delete_node_role_dimension(session):
     try:
         network_name = "n1"
         bf_set_network(network_name)
@@ -161,7 +161,7 @@ def test_delete_node_role_dimension():
 
 
 @requires_bf("2019.12.07")
-def test_put_node_role_dimension():
+def test_put_node_role_dimension(session):
     try:
         network_name = "n1"
         bf_set_network(network_name)

--- a/tests/integration/test_network_funcs.py
+++ b/tests/integration/test_network_funcs.py
@@ -38,6 +38,7 @@ from pybatfish.client.extended import (
     bf_put_network_object,
 )
 from pybatfish.client.options import Options
+from pybatfish.client.session import Session
 from pybatfish.datamodel.primitives import AutoCompleteSuggestion
 from pybatfish.datamodel.referencelibrary import (
     NodeRoleDimension,
@@ -58,6 +59,12 @@ def network():
     yield name
     # cleanup
     bf_delete_network(name)
+
+
+@fixture(scope="module")
+def session():
+    s = Session()
+    return s
 
 
 def test_delete_network_object(network):

--- a/tests/integration/test_snapshot_funcs.py
+++ b/tests/integration/test_snapshot_funcs.py
@@ -222,13 +222,6 @@ def test_list_snapshots(network, example_snapshot):
     assert verbose[0][BfConsts.PROP_NAME] == example_snapshot
 
 
-def test_get_snapshot_inferred_node_role_dimension(network, roles_snapshot):
-    bf_set_network(network)
-    bf_set_snapshot(roles_snapshot)
-    # should not crash
-    bf_get_snapshot_inferred_node_role_dimension("auto0")
-
-
 def test_get_snapshot_inferred_node_roles(network, roles_snapshot):
     bf_set_network(network)
     bf_set_snapshot(roles_snapshot)


### PR DESCRIPTION
Since some of the functionality is backwards-incompatible, mark it as such in tests.
Also delete a useless role inference test.

Build here: https://buildkite.com/intentionet/open-source-docker-pipeline/builds/325

Deferring cleanup till later. 