### PR TITLE
Add incoming interfaces and transformation to MatchSessionStepDetail

### DIFF
--- a/pybatfish/datamodel/flow.py
+++ b/pybatfish/datamodel/flow.py
@@ -501,16 +501,33 @@ class InboundStepDetail(DataModelElement):
 
 @attr.s(frozen=True)
 class MatchSessionStepDetail(DataModelElement):
-    """Details of a step for when a flow matches a firewall session."""
+    """Details of a step for when a flow matches a firewall session.
+
+    :ivar incomingInterfaces: List of incoming interfaces the session accepts
+    :ivar transformation: List of FlowDiffs that will be applied after session match
+    """
+
+    incomingInterfaces = attr.ib(type=List[str])
+    transformation = attr.ib(type=Optional[List[FlowDiff]], factory=list)
 
     @classmethod
     def from_dict(cls, json_dict):
         # type: (Dict) -> MatchSessionStepDetail
-        return MatchSessionStepDetail()
+        return MatchSessionStepDetail(
+            json_dict.get("incomingInterfaces", []),
+            [FlowDiff.from_dict(diff) for diff in json_dict.get("transformation", [])],
+        )
 
     def __str__(self):
         # type: () -> str
-        return ""
+        strings = [
+            "Incoming Interfaces: [{}]".format(", ".join(self.incomingInterfaces)),
+        ]
+        if self.transformation:
+            strings.append(
+                "Transformation: [{}]".format(", ".join(map(str, self.transformation)))
+            )
+        return ", ".join(strings)
 
 
 @attr.s(frozen=True)

--- a/tests/datamodel/test_flow.py
+++ b/tests/datamodel/test_flow.py
@@ -542,12 +542,26 @@ def test_SetupSessionStepDetail_str():
 
 
 def test_MatchSessionStepDetail_from_dict():
-    d = {"type": "MatchSession", "action": "MATCHED_SESSION"}
-    assert MatchSessionStepDetail.from_dict(d) == MatchSessionStepDetail()
+    d = {
+        "incomingInterfaces": ["reth0.6"],
+        "transformation": [
+            {"fieldName": "srcIp", "oldValue": "2.2.2.2", "newValue": "1.1.1.1"}
+        ],
+    }
+    assert MatchSessionStepDetail.from_dict(d) == MatchSessionStepDetail(
+        ["reth0.6"], [FlowDiff("srcIp", "2.2.2.2", "1.1.1.1")],
+    )
 
 
 def test_MatchSessionStepDetail_str():
-    assert str(MatchSessionStepDetail()) == ""
+    detail = MatchSessionStepDetail(
+        ["reth0.6"], [FlowDiff("srcIp", "2.2.2.2", "1.1.1.1")],
+    )
+    assert str(detail) == (
+        "Incoming Interfaces: [reth0.6], Transformation: [srcIp: 2.2.2.2 -> 1.1.1.1]"
+    )
+    detail = MatchSessionStepDetail(["reth0.6"])
+    assert str(detail) == "Incoming Interfaces: [reth0.6]"
 
 
 def test_header_constraints_of():


### PR DESCRIPTION
Session action and match criteria are trickier since they involve creating new data classes, so I'm breaking them into different PRs.

For the `MatchSessionStepDetail` in this PR, an example output would be:
<img width="658" alt="Screen Shot 2020-01-02 at 3 21 02 PM" src="https://user-images.githubusercontent.com/2776892/71699507-a5d6de80-2d74-11ea-8957-98df2d8e96ba.png">
