### PR TITLE
Simplify AclTraceEvent

### DIFF
--- a/jupyter_notebooks/Analyzing ACLs and Firewall Rules.ipynb
+++ b/jupyter_notebooks/Analyzing ACLs and Firewall Rules.ipynb
@@ -172,7 +172,7 @@
        "                        <td id=\"T_pybfstylerow0_col2\" class=\"data row0 col2\" >Start Location: rtr-with-acl<br>Src IP: 10.10.10.1<br>Src Port: 49152<br>Dst IP: 218.8.104.58<br>Dst Port: 53<br>IP Protocol: UDP</td>\n",
        "                        <td id=\"T_pybfstylerow0_col3\" class=\"data row0 col3\" >PERMIT</td>\n",
        "                        <td id=\"T_pybfstylerow0_col4\" class=\"data row0 col4\" >660 permit udp 10.10.10.0/24 218.8.104.58/32 eq domain</td>\n",
-       "                        <td id=\"T_pybfstylerow0_col5\" class=\"data row0 col5\" >AclTrace(events=[AclTraceEvent(class_name=&#x27;org.batfish.datamodel.acl.PermittedByAclLine&#x27;, description=&#x27;Flow permitted by extended ipv4 access-list named acl_in, index 32: 660 permit udp 10.10.10.0/24 218.8.104.58/32 eq domain&#x27;, lineDescription=&#x27;660 permit udp 10.10.10.0/24 218.8.104.58/32 eq domain&#x27;)])</td>\n",
+       "                        <td id=\"T_pybfstylerow0_col5\" class=\"data row0 col5\" >AclTrace(events=[AclTraceEvent(description=&#x27;Flow permitted by extended ipv4 access-list named acl_in, index 32: 660 permit udp 10.10.10.0/24 218.8.104.58/32 eq domain&#x27;)])</td>\n",
        "            </tr>\n",
        "    </tbody></table>"
       ],
@@ -279,7 +279,7 @@
        "                        <td id=\"T_pybfstylerow0_col2\" class=\"data row0 col2\" >Start Location: firewall interface=GigabitEthernet0/0/2<br>Src IP: 10.114.64.1<br>Src Port: 49152<br>Dst IP: 10.114.60.10<br>Dst Port: 80<br>IP Protocol: TCP</td>\n",
        "                        <td id=\"T_pybfstylerow0_col3\" class=\"data row0 col3\" >DENY</td>\n",
        "                        <td id=\"T_pybfstylerow0_col4\" class=\"data row0 col4\" >no-match</td>\n",
-       "                        <td id=\"T_pybfstylerow0_col5\" class=\"data row0 col5\" >AclTrace(events=[AclTraceEvent(class_name=&#x27;org.batfish.datamodel.acl.DefaultDeniedByIpAccessList&#x27;, description=&quot;Flow did not match ACL named &#x27;~ZONE_OUTGOING_ACL~zone-z3~&#x27;&quot;, lineDescription=None)])</td>\n",
+       "                        <td id=\"T_pybfstylerow0_col5\" class=\"data row0 col5\" >AclTrace(events=[AclTraceEvent(description=&quot;Flow did not match ACL named &#x27;~ZONE_OUTGOING_ACL~zone-z3~&#x27;&quot;)])</td>\n",
        "            </tr>\n",
        "    </tbody></table>"
       ],
@@ -408,7 +408,7 @@
        "                        <td id=\"T_pybfstylerow0_col2\" class=\"data row0 col2\" >Start Location: rtr-with-acl<br>Src IP: 10.10.10.42<br>Src Port: 0<br>Dst IP: 218.8.104.58<br>Dst Port: 53<br>IP Protocol: UDP</td>\n",
        "                        <td id=\"T_pybfstylerow0_col3\" class=\"data row0 col3\" >DENY</td>\n",
        "                        <td id=\"T_pybfstylerow0_col4\" class=\"data row0 col4\" >460 deny udp 10.10.10.42/32 218.8.104.58/32 eq domain</td>\n",
-       "                        <td id=\"T_pybfstylerow0_col5\" class=\"data row0 col5\" >AclTrace(events=[AclTraceEvent(class_name=&#x27;org.batfish.datamodel.acl.DeniedByAclLine&#x27;, description=&#x27;Flow denied by extended ipv4 access-list named acl_in, index 22: 460 deny udp 10.10.10.42/32 218.8.104.58/32 eq domain&#x27;, lineDescription=&#x27;460 deny udp 10.10.10.42/32 218.8.104.58/32 eq domain&#x27;)])</td>\n",
+       "                        <td id=\"T_pybfstylerow0_col5\" class=\"data row0 col5\" >AclTrace(events=[AclTraceEvent(description=&#x27;Flow denied by extended ipv4 access-list named acl_in, index 22: 460 deny udp 10.10.10.42/32 218.8.104.58/32 eq domain&#x27;)])</td>\n",
        "            </tr>\n",
        "    </tbody></table>"
       ],

--- a/jupyter_notebooks/Provably Safe ACL and Firewall Changes.ipynb
+++ b/jupyter_notebooks/Provably Safe ACL and Firewall Changes.ipynb
@@ -405,8 +405,8 @@
        "                        <td id=\"T_pybfstylerow0_col5\" class=\"data row0 col5\" >DENY</td>\n",
        "                        <td id=\"T_pybfstylerow0_col6\" class=\"data row0 col6\" >462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80</td>\n",
        "                        <td id=\"T_pybfstylerow0_col7\" class=\"data row0 col7\" >2020 deny tcp any any</td>\n",
-       "                        <td id=\"T_pybfstylerow0_col8\" class=\"data row0 col8\" >AclTrace(events=[AclTraceEvent(class_name=&#x27;org.batfish.datamodel.acl.PermittedByAclLine&#x27;, description=&#x27;Flow permitted by extended ipv4 access-list named acl_in, index 23: 462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80&#x27;, lineDescription=&#x27;462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80&#x27;)])</td>\n",
-       "                        <td id=\"T_pybfstylerow0_col9\" class=\"data row0 col9\" >AclTrace(events=[AclTraceEvent(class_name=&#x27;org.batfish.datamodel.acl.DeniedByAclLine&#x27;, description=&#x27;Flow denied by extended ipv4 access-list named acl_in, index 101: 2020 deny tcp any any&#x27;, lineDescription=&#x27;2020 deny tcp any any&#x27;)])</td>\n",
+       "                        <td id=\"T_pybfstylerow0_col8\" class=\"data row0 col8\" >AclTrace(events=[AclTraceEvent(description=&#x27;Flow permitted by extended ipv4 access-list named acl_in, index 23: 462 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 80&#x27;)])</td>\n",
+       "                        <td id=\"T_pybfstylerow0_col9\" class=\"data row0 col9\" >AclTrace(events=[AclTraceEvent(description=&#x27;Flow denied by extended ipv4 access-list named acl_in, index 101: 2020 deny tcp any any&#x27;)])</td>\n",
        "            </tr>\n",
        "    </tbody></table>"
       ],

--- a/pybatfish/datamodel/acl.py
+++ b/pybatfish/datamodel/acl.py
@@ -25,31 +25,19 @@ __all__ = ["AclTrace", "AclTraceEvent"]
 class AclTraceEvent(DataModelElement):
     """One event corresponding to a packet's life through an ACL.
 
-    :ivar class_name: The type of the event that occurred while tracing.
     :ivar description: The description of the event
-    :ivar lineDescription: ACL line that caused the event (if applicable)
     """
 
-    class_name = attr.ib(type=Optional[str], default=None)
     description = attr.ib(type=Optional[str], default=None)
-    lineDescription = attr.ib(type=Optional[str], default=None)
 
     @classmethod
     def from_dict(cls, json_dict):
         # type: (Dict) -> AclTraceEvent
-        return AclTraceEvent(
-            json_dict.get("class"),
-            json_dict.get("description"),
-            json_dict.get("lineDescription"),
-        )
+        return AclTraceEvent(json_dict.get("description"))
 
     def __str__(self):
         # type: () -> str
-        if self.description is not None:
-            return self.description
-        if self.lineDescription is not None:
-            return self.lineDescription
-        return repr(self)
+        return str(self.description)
 
 
 @attr.s(frozen=True)
@@ -70,4 +58,7 @@ class AclTrace(DataModelElement):
 
     def __str__(self):
         # type: () -> str
-        return "\n".join(str(event) for event in self.events)
+        return "\n".join(
+            str(event)
+            for event in self.events
+            if event.description is not None)

--- a/pybatfish/datamodel/acl.py
+++ b/pybatfish/datamodel/acl.py
@@ -59,6 +59,5 @@ class AclTrace(DataModelElement):
     def __str__(self):
         # type: () -> str
         return "\n".join(
-            str(event)
-            for event in self.events
-            if event.description is not None)
+            str(event) for event in self.events if event.description is not None
+        )

--- a/tests/datamodel/test_traceevent.py
+++ b/tests/datamodel/test_traceevent.py
@@ -16,36 +16,30 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from pybatfish.datamodel.acl import AclTraceEvent
+from pybatfish.datamodel.acl import AclTrace, AclTraceEvent
 
 
 # test if a trace event with description is deserialized and string-ified properly
 def test_trace_event_with_description():
-    dict = {"description": "aa", "class": "Permitted"}
+    dict = {"description": "aa"}
 
     # check deserialization
     trace_event = AclTraceEvent.from_dict(dict)
-    assert trace_event.class_name == "Permitted"
     assert trace_event.description == "aa"
 
     # check str
     event_str = str(trace_event)
     assert "aa" in event_str
-    assert "PermittedDenied" not in event_str
 
 
-# test if a trace event without description is deserialized and string-ified properly
-def test_trace_event_without_description():
-    dict = {"class": "Permitted"}
+def test_trace_str():
+    event1 = {"description": "event1"}
+    event2 = {}
+    event3 = {"description": "event3"}
+    events = [event1, event2, event3]
+    trace = AclTrace.from_dict({"events": events})
 
-    # check deserialization
-    trace_event = AclTraceEvent.from_dict(dict)
-    assert trace_event.class_name == "Permitted"
-    assert trace_event.description is None
-
-    # check str
-    event_str = str(trace_event)
-    assert "Permitted" in event_str
+    assert str(trace) == "event1\nevent3"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We only care about the description, so ignore any other fields.
If description is missing, exclude the event from the trace.