### PR TITLE
Add readthedocs config as a yaml file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+nbsphinx
+pandoc
+progressbar2
+pytablewriter
+recommonmark
+sphinx>=2.3.1
+sphinx-notfound-page


### PR DESCRIPTION
It's more flexible than the web interface, and can be versioned.

Also, adding an additional requirements file as part of prep work for #541 