### PR TITLE
New docs: fix RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,8 @@ sphinx:
   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats:
+  - htmlzip
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - ca-certificates=2019.11.27
   - certifi=2019.11.28
+  - ipython=7.8.0
   - libedit=3.1.20181209
   - libffi=3.2.1
   - ncurses=6.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 cerberus==1.3.2
 inflection==0.3.1
+ipython==7.8.0
 nbsphinx==0.5.0
 progressbar2==3.47.0
 recommonmark==0.6.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ["_build", "**.ipynb_checkpoints"]
+exclude_patterns = ["build", "**.ipynb_checkpoints"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"


### PR DESCRIPTION
Get rid of "Pygments lexer name 'ipython3' is not known" error