### PR TITLE
Pin ipython; it has dropped support for py3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,8 @@ setup(
             "check-manifest",
             "coverage",
             "inflection",
+            # To support py3.5
+            "ipython<7.10.0",
             "jupyter",
             "mypy",
             "nbformat<5.0.0",


### PR DESCRIPTION
https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#stop-support-for-python-3-5-adopt-nep-29