### PR TITLE
Fix requests adapters

### DIFF
--- a/pybatfish/client/_diagnostics.py
+++ b/pybatfish/client/_diagnostics.py
@@ -67,9 +67,8 @@ _UPLOAD_RETRY_BACKOFF = 0.3
 
 # Setup a session, configure retry policy
 _requests_session = requests.Session()
-# Prefix "http" will cover both "http" & "https"
 _requests_session.mount(
-    "http",
+    "https://",
     HTTPAdapter(
         max_retries=Retry(
             total=_UPLOAD_MAX_TRIES,

--- a/pybatfish/client/_diagnostics.py
+++ b/pybatfish/client/_diagnostics.py
@@ -67,18 +67,16 @@ _UPLOAD_RETRY_BACKOFF = 0.3
 
 # Setup a session, configure retry policy
 _requests_session = requests.Session()
-_requests_session.mount(
-    "https://",
-    HTTPAdapter(
-        max_retries=Retry(
-            total=_UPLOAD_MAX_TRIES,
-            backoff_factor=_UPLOAD_RETRY_BACKOFF,
-            status_forcelist=[500, 502, 503, 504, 104],
-            # Retry on all calls, including POST
-            method_whitelist=False,
-        )
-    ),
+_adapter = HTTPAdapter(
+    max_retries=Retry(
+        total=_UPLOAD_MAX_TRIES,
+        backoff_factor=_UPLOAD_RETRY_BACKOFF,
+        status_forcelist=[500, 502, 503, 504, 104],
+        # Retry on all calls, including POST
+        method_whitelist=False,
+    )
 )
+_requests_session.mount("https://", _adapter)
 
 
 def upload_diagnostics(

--- a/pybatfish/client/_diagnostics.py
+++ b/pybatfish/client/_diagnostics.py
@@ -74,6 +74,8 @@ _requests_session.mount(
             total=_UPLOAD_MAX_TRIES,
             backoff_factor=_UPLOAD_RETRY_BACKOFF,
             status_forcelist=[500, 502, 503, 504, 104],
+            # Retry on all calls, including POST
+            method_whitelist=False,
         )
     ),
 )

--- a/pybatfish/client/resthelper.py
+++ b/pybatfish/client/resthelper.py
@@ -37,17 +37,18 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 # Setup a session, configure retry policy
 _requests_session = requests.Session()
-# Prefix "http" will cover both "http" & "https"
-_requests_session.mount(
-    "http",
-    HTTPAdapter(
-        max_retries=Retry(
-            connect=Options.max_tries_to_connect_to_coordinator,
-            read=Options.max_tries_to_connect_to_coordinator,
-            backoff_factor=Options.request_backoff_factor,
-        )
-    ),
+_adapter = HTTPAdapter(
+    max_retries=Retry(
+        connect=Options.max_tries_to_connect_to_coordinator,
+        read=Options.max_tries_to_connect_to_coordinator,
+        backoff_factor=Options.request_backoff_factor,
+        # Retry on all calls, including POST
+        method_whitelist=False,
+    )
 )
+# Configure retries for http and https requests
+_requests_session.mount("http://", _adapter)
+_requests_session.mount("https://", _adapter)
 
 
 # uncomment line below if you want http capture by fiddler

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -41,17 +41,18 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 # Setup a session, configure retry policy
 _requests_session = requests.Session()
-# Prefix "http" will cover both "http" & "https"
-_requests_session.mount(
-    "http",
-    HTTPAdapter(
-        max_retries=Retry(
-            connect=Options.max_tries_to_connect_to_coordinator,
-            read=Options.max_tries_to_connect_to_coordinator,
-            backoff_factor=Options.request_backoff_factor,
-        )
-    ),
+_adapter = HTTPAdapter(
+    max_retries=Retry(
+        connect=Options.max_tries_to_connect_to_coordinator,
+        read=Options.max_tries_to_connect_to_coordinator,
+        backoff_factor=Options.request_backoff_factor,
+        # Retry on all calls, including POST
+        method_whitelist=False,
+    )
 )
+# Configure retries for http and https requests
+_requests_session.mount("http://", _adapter)
+_requests_session.mount("https://", _adapter)
 
 _encoder = BfJsonEncoder()
 

--- a/tests/client/test_diagnostics.py
+++ b/tests/client/test_diagnostics.py
@@ -150,7 +150,14 @@ def test_upload_to_url_session(config_dir):
 
 def test_session_retry():
     """Confirm session is configured with correct https adapter."""
+    # HTTP status codes we need to retry on
+    codes = (500, 502, 503, 504, 104)
+
     https = _requests_session.adapters["https://"]
     assert https == _adapter
     # Also make sure retries are configured
-    assert _adapter.max_retries.total == _UPLOAD_MAX_TRIES
+    retries = _adapter.max_retries
+    assert retries.total == _UPLOAD_MAX_TRIES
+    # All request types should be retried
+    assert not retries.method_whitelist
+    assert all(code in retries.status_forcelist for code in codes)

--- a/tests/client/test_diagnostics.py
+++ b/tests/client/test_diagnostics.py
@@ -24,7 +24,10 @@ import responses
 
 from pybatfish.client._diagnostics import (
     METADATA_FILENAME,
+    _UPLOAD_MAX_TRIES,
+    _adapter,
     _anonymize_dir,
+    _requests_session,
     _upload_dir_to_url,
     check_if_all_passed,
     check_if_any_failed,
@@ -143,3 +146,11 @@ def test_upload_to_url_session(config_dir):
         _upload_dir_to_url(base_url=base_url, src_dir=config_dir)
     # Should pass through to the correct session
     assert requests_session.put.called
+
+
+def test_session_retry():
+    """Confirm session is configured with correct https adapter."""
+    https = _requests_session.adapters["https://"]
+    assert https == _adapter
+    # Also make sure retries are configured
+    assert _adapter.max_retries.total == _UPLOAD_MAX_TRIES

--- a/tests/client/test_resthelper.py
+++ b/tests/client/test_resthelper.py
@@ -24,4 +24,7 @@ def test_session_adapters():
     assert http == _adapter
     assert https == _adapter
     # Also make sure retries are configured
-    assert _adapter.max_retries.total == Options.max_tries_to_connect_to_coordinator
+    retries = _adapter.max_retries
+    assert retries.total == Options.max_tries_to_connect_to_coordinator
+    # All request types should be retried
+    assert not retries.method_whitelist

--- a/tests/client/test_resthelper.py
+++ b/tests/client/test_resthelper.py
@@ -1,0 +1,27 @@
+#   Copyright 2018 The Batfish Open Source Project
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from pybatfish.client.options import Options
+from pybatfish.client.resthelper import _adapter, _requests_session
+
+
+def test_session_adapters():
+    """Confirm session is configured with correct http and https adapters."""
+    http = _requests_session.adapters["http://"]
+    https = _requests_session.adapters["https://"]
+
+    assert http == _adapter
+    assert https == _adapter
+    # Also make sure retries are configured
+    assert _adapter.max_retries.total == Options.max_tries_to_connect_to_coordinator

--- a/tests/client/test_restv2helper.py
+++ b/tests/client/test_restv2helper.py
@@ -154,7 +154,10 @@ def test_session_adapters():
     assert http == _adapter
     assert https == _adapter
     # Also make sure retries are configured
-    assert _adapter.max_retries.total == Options.max_tries_to_connect_to_coordinator
+    retries = _adapter.max_retries
+    assert retries.total == Options.max_tries_to_connect_to_coordinator
+    # All request types should be retried
+    assert not retries.method_whitelist
 
 
 if __name__ == "__main__":

--- a/tests/client/test_restv2helper.py
+++ b/tests/client/test_restv2helper.py
@@ -19,13 +19,16 @@ import requests
 from requests import HTTPError, Response
 
 from pybatfish.client import restv2helper
+from pybatfish.client.options import Options
 from pybatfish.client.restv2helper import (
+    _adapter,
     _delete,
     _encoder,
     _get,
     _get_headers,
     _post,
     _put,
+    _requests_session,
 )
 from pybatfish.client.session import Session
 
@@ -141,6 +144,17 @@ def test_put(session, request_session):
         verify=session.verify_ssl_certs,
         params=None,
     )
+
+
+def test_session_adapters():
+    """Confirm session is configured with correct http and https adapters."""
+    http = _requests_session.adapters["http://"]
+    https = _requests_session.adapters["https://"]
+
+    assert http == _adapter
+    assert https == _adapter
+    # Also make sure retries are configured
+    assert _adapter.max_retries.total == Options.max_tries_to_connect_to_coordinator
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Old adapters were configured incorrectly (ignored in favor of default longer-prefix adapters `https://` and `http://` [see here for more details](https://requests-mock.readthedocs.io/en/latest/adapter.html)).

This PR adds retry for failed POST calls as well as overriding the default http and https adapters, so we actually retry.
