### PR TITLE
Auto-complete: fix integration tests

### DIFF
--- a/tests/integration/test_network_funcs.py
+++ b/tests/integration/test_network_funcs.py
@@ -19,11 +19,13 @@ from requests.exceptions import HTTPError
 
 from pybatfish.client.commands import (
     bf_add_node_role_dimension,
+    bf_auto_complete,
     bf_delete_network,
     bf_delete_node_role_dimension,
     bf_get_node_role_dimension,
     bf_get_node_roles,
     bf_get_reference_book,
+    bf_init_snapshot,
     bf_list_networks,
     bf_put_node_role_dimension,
     bf_put_node_roles,
@@ -213,7 +215,21 @@ def test_put_reference_book():
         bf_delete_network(network_name)
 
 
-def auto_complete_tester(session, completion_types):
+def auto_complete_tester(completion_types):
+    try:
+        name = bf_set_network()
+        bf_init_snapshot(join(_this_dir, "snapshot"))
+        for completion_type in completion_types:
+            suggestions = bf_auto_complete(completion_type, ".*")
+            # Not all completion types will have suggestions since this test snapshot only contains one empty config.
+            # If a completion type is unsupported an error is thrown so this will test that no errors are thrown.
+            if len(suggestions) > 0:
+                assert isinstance(suggestions[0], AutoCompleteSuggestion)
+    finally:
+        bf_delete_network(name)
+
+
+def auto_complete_tester_session(session, completion_types):
     try:
         name = session.set_network()
         session.init_snapshot(join(_this_dir, "snapshot"))
@@ -227,8 +243,8 @@ def auto_complete_tester(session, completion_types):
         session.delete_network(name)
 
 
-def test_auto_complete(session):
-    auto_complete_tester(session, COMPLETION_TYPES)
+def test_auto_complete():
+    auto_complete_tester(COMPLETION_TYPES)
 
 
 @requires_bf("2020.09.28")
@@ -236,4 +252,4 @@ def test_auto_complete_routing_policy_spec(session):
     """
     This type was newly added, so we test it separately. Move to conftest.py/COMPLETION_TYPES later.
     """
-    auto_complete_tester(session, [VariableType.ROUTING_POLICY_SPEC])
+    auto_complete_tester_session(session, [VariableType.ROUTING_POLICY_SPEC])


### PR DESCRIPTION
Fix auto-complete tests to only use new session method for the new test.
