### PR TITLE
Coordinator Errors: limit retries for other issues

### DIFF
--- a/pybatfish/client/resthelper.py
+++ b/pybatfish/client/resthelper.py
@@ -39,6 +39,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 _requests_session = requests.Session()
 _adapter = HTTPAdapter(
     max_retries=Retry(
+        total=Options.max_retries_to_connect_to_coordinator,
         connect=Options.max_retries_to_connect_to_coordinator,
         read=Options.max_retries_to_connect_to_coordinator,
         backoff_factor=Options.request_backoff_factor,

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -14,7 +14,8 @@
 
 from __future__ import absolute_import, print_function
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Text, Union  # noqa: F401
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Text, \
+    Union  # noqa: F401
 
 import requests
 from requests import HTTPError, Response  # noqa: F401
@@ -46,6 +47,7 @@ _STATUS_FORCELIST = [429, 500, 502, 503, 504]
 _requests_session = requests.Session()
 _adapter = HTTPAdapter(
     max_retries=Retry(
+        total=Options.max_retries_to_connect_to_coordinator,
         connect=Options.max_retries_to_connect_to_coordinator,
         read=Options.max_retries_to_connect_to_coordinator,
         backoff_factor=Options.request_backoff_factor,
@@ -62,6 +64,7 @@ _requests_session.mount("https://", _adapter)
 _requests_session_fail_fast = requests.Session()
 _adapter_fail_fast = HTTPAdapter(
     max_retries=Retry(
+        total=Options.max_initial_tries_to_connect_to_coordinator,
         connect=Options.max_initial_tries_to_connect_to_coordinator,
         read=Options.max_initial_tries_to_connect_to_coordinator,
         backoff_factor=Options.request_backoff_factor,

--- a/pybatfish/client/restv2helper.py
+++ b/pybatfish/client/restv2helper.py
@@ -14,8 +14,7 @@
 
 from __future__ import absolute_import, print_function
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Text, \
-    Union  # noqa: F401
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Text, Union  # noqa: F401
 
 import requests
 from requests import HTTPError, Response  # noqa: F401

--- a/tests/client/test_resthelper.py
+++ b/tests/client/test_resthelper.py
@@ -25,6 +25,7 @@ def test_session_adapters():
     assert https == _adapter
     # Also make sure retries are configured
     retries = _adapter.max_retries
+    assert retries.total == Options.max_retries_to_connect_to_coordinator
     assert retries.connect == Options.max_retries_to_connect_to_coordinator
     assert retries.read == Options.max_retries_to_connect_to_coordinator
     # All request types should be retried

--- a/tests/client/test_restv2helper.py
+++ b/tests/client/test_restv2helper.py
@@ -173,6 +173,7 @@ def test_session_adapters():
     assert https == _adapter
     # Also make sure retries are configured
     retries = _adapter.max_retries
+    assert total.connect == Options.max_retries_to_connect_to_coordinator
     assert retries.connect == Options.max_retries_to_connect_to_coordinator
     assert retries.read == Options.max_retries_to_connect_to_coordinator
     # All request types should be retried
@@ -187,6 +188,7 @@ def test_fail_fast_session_adapters():
     assert https == _adapter_fail_fast
     # Also make sure retries are configured correctly
     retries = _adapter_fail_fast.max_retries
+    assert retries.total == Options.max_initial_tries_to_connect_to_coordinator
     assert retries.connect == Options.max_initial_tries_to_connect_to_coordinator
     assert retries.read == Options.max_initial_tries_to_connect_to_coordinator
     # All request types should be retried

--- a/tests/client/test_restv2helper.py
+++ b/tests/client/test_restv2helper.py
@@ -173,7 +173,7 @@ def test_session_adapters():
     assert https == _adapter
     # Also make sure retries are configured
     retries = _adapter.max_retries
-    assert total.connect == Options.max_retries_to_connect_to_coordinator
+    assert retries.total == Options.max_retries_to_connect_to_coordinator
     assert retries.connect == Options.max_retries_to_connect_to_coordinator
     assert retries.read == Options.max_retries_to_connect_to_coordinator
     # All request types should be retried


### PR DESCRIPTION
Explicitly set `total` retries so it doesn't default to a large value (10 for urllib3 `1.25.8`). This allows misc errors (e.g. SSLErrors/bad certificate) to timeout quickly when establishing new connections to the backend.
