### PR TITLE
Notebook Testing: add ability to skip tests for old versions

### DIFF
--- a/tests/common_util.py
+++ b/tests/common_util.py
@@ -57,9 +57,7 @@ def skip_old_version(bf_version, min_version):
     print("min_version, bf_version: {}, {}".format(min_version, bf_version))
     if _version_less_than(_version_to_tuple(bf_version), min_version_tuple):
         print("BF version too low")
-        pytest.skip(
-            "Batfish version too low ({} < {})".format(bf_version, min_version)
-        )
+        pytest.skip("Batfish version too low ({} < {})".format(bf_version, min_version))
     pybf_version = _get_pybf_version()
     if _version_less_than(_version_to_tuple(pybf_version), min_version_tuple):
         print("PYBF version too low")

--- a/tests/common_util.py
+++ b/tests/common_util.py
@@ -51,6 +51,29 @@ def _version_less_than(version, min_version):
     return False
 
 
+def skip_old_version(bf_version, min_version):
+    """Skip this pytest test if specified (or inferred) Pybf/Bf version is below supplied, minimum required version."""
+    min_version_tuple = _version_to_tuple(min_version)
+    print("min_version, bf_version: {}, {}".format(min_version, bf_version))
+    if _version_less_than(_version_to_tuple(bf_version), min_version_tuple):
+        print("BF version too low")
+        pytest.skip(
+            "Batfish version too low ({} < {})".format(bf_version, min_version)
+        )
+    pybf_version = _get_pybf_version()
+    if _version_less_than(_version_to_tuple(pybf_version), min_version_tuple):
+        print("PYBF version too low")
+        pytest.skip(
+            "Pybatfish version too low ({} < {})".format(pybf_version, min_version)
+        )
+
+
+def get_bf_version(session):
+    """Get BF version."""
+    # Use env var as version number if specified (get around some backends having dev version number)
+    return os.environ.get("bf_version", session._get_bf_version())
+
+
 def requires_bf(version):
     """
     Decorator that will skip a test if the Batfish or Pybatfish version is older than the specified version.
@@ -62,8 +85,6 @@ def requires_bf(version):
     # This outer decorator only accepts version string, not the actual
     # target function
 
-    min_version = _version_to_tuple(version)
-
     def function_decorator(func):
         # Inner 'decorator' accepts the target function
 
@@ -73,26 +94,18 @@ def requires_bf(version):
             if not bf_version:
                 for a in args:
                     if isinstance(a, Session):
-                        bf_version = a._get_bf_version()
+                        bf_version = get_bf_version(a)
                         break
                 for k in kwargs:
                     arg = kwargs[k]
                     if isinstance(arg, Session):
-                        bf_version = arg._get_bf_version()
+                        bf_version = get_bf_version(arg)
                         break
             if not bf_version:
                 raise ValueError(
                     "Bad Batfish version.  Make sure either the bf_version env var is set or the decorated test accepts a session fixture."
                 )
-            if _version_less_than(_version_to_tuple(bf_version), min_version):
-                pytest.skip(
-                    "Batfish version too low ({} < {})".format(bf_version, version)
-                )
-            pybf_version = _get_pybf_version()
-            if _version_less_than(_version_to_tuple(pybf_version), min_version):
-                pytest.skip(
-                    "Pybatfish version too low ({} < {})".format(pybf_version, version)
-                )
+            skip_old_version(bf_version=bf_version, min_version=version)
             return func(*args, **kwargs)
 
         return decorator(wrapper, func)

--- a/tests/common_util.py
+++ b/tests/common_util.py
@@ -54,13 +54,10 @@ def _version_less_than(version, min_version):
 def skip_old_version(bf_version, min_version):
     """Skip this pytest test if specified (or inferred) Pybf/Bf version is below supplied, minimum required version."""
     min_version_tuple = _version_to_tuple(min_version)
-    print("min_version, bf_version: {}, {}".format(min_version, bf_version))
     if _version_less_than(_version_to_tuple(bf_version), min_version_tuple):
-        print("BF version too low")
         pytest.skip("Batfish version too low ({} < {})".format(bf_version, min_version))
     pybf_version = _get_pybf_version()
     if _version_less_than(_version_to_tuple(pybf_version), min_version_tuple):
-        print("PYBF version too low")
         pytest.skip(
             "Pybatfish version too low ({} < {})".format(pybf_version, min_version)
         )
@@ -68,7 +65,7 @@ def skip_old_version(bf_version, min_version):
 
 def get_bf_version(session):
     """Get BF version."""
-    # Use env var as version number if specified (get around some backends having dev version number)
+    # Use env var as version number if specified (get around some backends incorrectly having dev version number)
     return os.environ.get("bf_version", session._get_bf_version())
 
 

--- a/tests/integration/test_notebook.py
+++ b/tests/integration/test_notebook.py
@@ -23,6 +23,9 @@ import nbformat
 import pytest
 from nbconvert.preprocessors import ExecutePreprocessor
 
+from pybatfish.client.session import Session
+from tests.common_util import get_bf_version, skip_old_version
+
 _this_dir = abspath(dirname(realpath(__file__)))
 _root_dir = abspath(join(_this_dir, pardir, pardir))
 _jupyter_nb_dir = join(_root_dir, "jupyter_notebooks")
@@ -33,6 +36,11 @@ notebook_files = [
     for filename in files
     if ".ipynb_checkpoints" not in root and filename.endswith(".ipynb")
 ]
+# Map of notebook name (substring) to minimum Pybf/Bf version required to run it
+notebook_min_versions = {
+    # e.g. don't run Analyzing Routing Policies on Pybf or Bf version before 2020.10.02
+    # "Analyzing Routing Policies": "2020.10.02",
+}
 
 for root, dirs, files in walk(_jupyter_nb_dir):
     for filename in files:
@@ -44,10 +52,23 @@ assert len(notebook_files) > 0
 _check_cell_types = ["execute_result", "display_data"]
 
 
+@pytest.fixture(scope="module")
+def session():
+    s = Session()
+    return s
+
+
 @pytest.fixture(scope="module", params=notebook_files)
 def notebook(request):
     filepath = request.param
     return filepath, nbformat.read(filepath, as_version=4)
+
+
+def skip_new_notebook_vs_old_code(session, notebook_name):
+    """Skip this pytest test if version of Pybf and Bf are too old to run it."""
+    for key in notebook_min_versions:
+        if key in notebook_name:
+            skip_old_version(get_bf_version(session), notebook_min_versions.get(key))
 
 
 def _is_warning_output(o):
@@ -109,14 +130,17 @@ def _compare_data(original_data, executed_data):
         _compare_data_str(original_data["text/html"], executed_data["text/html"])
 
 
-def test_notebook_no_errors(executed_notebook):
+def test_notebook_no_errors(session, notebook, executed_notebook):
     """Asserts that the given notebook has no cells with error outputs."""
+    filepath, _ = notebook
+    skip_new_notebook_vs_old_code(session, filepath)
     for c in executed_notebook["cells"]:
         _assert_cell_no_errors(c)
 
 
-def test_notebook_output(notebook, executed_notebook):
+def test_notebook_output(session, notebook, executed_notebook):
     filepath, nb = notebook
+    skip_new_notebook_vs_old_code(session, filepath)
     try:
         for cell, executed_cell in zip(nb["cells"], executed_notebook["cells"]):
             assert cell["cell_type"] == executed_cell["cell_type"]

--- a/tests/integration/test_notebook.py
+++ b/tests/integration/test_notebook.py
@@ -53,9 +53,9 @@ _check_cell_types = ["execute_result", "display_data"]
 
 
 @pytest.fixture(scope="module")
-def session():
+def bf_version():
     s = Session()
-    return s
+    return get_bf_version(s)
 
 
 @pytest.fixture(scope="module", params=notebook_files)
@@ -64,11 +64,11 @@ def notebook(request):
     return filepath, nbformat.read(filepath, as_version=4)
 
 
-def skip_new_notebook_vs_old_code(session, notebook_name):
+def skip_new_notebook_vs_old_code(bf_version, notebook_name):
     """Skip this pytest test if version of Pybf and Bf are too old to run it."""
     for key in notebook_min_versions:
         if key in notebook_name:
-            skip_old_version(get_bf_version(session), notebook_min_versions.get(key))
+            skip_old_version(bf_version, notebook_min_versions.get(key))
 
 
 def _is_warning_output(o):
@@ -130,17 +130,17 @@ def _compare_data(original_data, executed_data):
         _compare_data_str(original_data["text/html"], executed_data["text/html"])
 
 
-def test_notebook_no_errors(session, notebook, executed_notebook):
+def test_notebook_no_errors(bf_version, notebook, executed_notebook):
     """Asserts that the given notebook has no cells with error outputs."""
     filepath, _ = notebook
-    skip_new_notebook_vs_old_code(session, filepath)
+    skip_new_notebook_vs_old_code(bf_version, filepath)
     for c in executed_notebook["cells"]:
         _assert_cell_no_errors(c)
 
 
-def test_notebook_output(session, notebook, executed_notebook):
+def test_notebook_output(bf_version, notebook, executed_notebook):
     filepath, nb = notebook
-    skip_new_notebook_vs_old_code(session, filepath)
+    skip_new_notebook_vs_old_code(bf_version, filepath)
     try:
         for cell, executed_cell in zip(nb["cells"], executed_notebook["cells"]):
             assert cell["cell_type"] == executed_cell["cell_type"]


### PR DESCRIPTION
Add ability to skip notebook tests for older versions of Batfish or Pybatfish.

Useful for new notebooks exercising new functionality not in older versions.
