### PR TITLE
CI: don't fail build if codecov is down

### DIFF
--- a/.buildkite/integration_tests.sh
+++ b/.buildkite/integration_tests.sh
@@ -9,4 +9,7 @@ tar -xzf workspace/questions.tgz
 java -cp workspace/allinone.jar org.batfish.allinone.Main -runclient false -coordinatorargs '-templatedirs questions -periodassignworkms=5' 2>&1 > workspace/batfish.log &
 pip install -e .[dev] -q
 pytest tests/integration
+
+# Let codecov upload fail - codecov goes down not infrequently.
+set +o pipefail
 bash <(curl -s https://codecov.io/bash) -t 91216eec-ae5e-4836-8ee5-1d5a71d1b5bc -F integration${version//.}

--- a/.buildkite/unit_tests.sh
+++ b/.buildkite/unit_tests.sh
@@ -5,4 +5,7 @@ set -euo pipefail
 version=$1
 pip install -e .[dev]
 pytest tests 
+
+# Let codecov upload fail - codecov goes down not infrequently.
+set +o pipefail
 bash <(curl -s https://codecov.io/bash) -t 91216eec-ae5e-4836-8ee5-1d5a71d1b5bc -F unit${version//.}


### PR DESCRIPTION
Over the weekend, codecov was down and all our builds failed. Let this step
soft-fail.

```
+ bash /dev/fd/63 -t 59baa5fe-139e-4aef-80a7-b40bfaa3fc67
++ curl -s https://codecov.io/bash
/dev/fd/63: line 2: syntax error near unexpected token `<'
/dev/fd/63: line 2: `<html><head>'
```