### PR TITLE
Setup: update programming language classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,11 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     # What does your project relate to?
     keywords="network configuration verification",


### PR DESCRIPTION
Classifiers were already stale, but now more-so after removing 3.5 support.
