### PR TITLE
Tests: fix diagnostic retry

### DIFF
--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -62,12 +62,10 @@ def requests_session():
     )
     # Override longest-match adapter for http and https
     session.mount(
-        "http://",
-        adapter,
+        "http://", adapter,
     )
     session.mount(
-        "https://",
-        adapter,
+        "https://", adapter,
     )
     yield session
 

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -53,17 +53,16 @@ def network():
 def requests_session():
     # Setup a session with a retry policy
     session = requests.Session()
-    # Prefix "http" will cover both "http" & "https"
-    session.mount(
-        "http",
-        HTTPAdapter(
-            max_retries=Retry(
-                total=_UPLOAD_MAX_TRIES,
-                backoff_factor=_UPLOAD_RETRY_BACKOFF,
-                status_forcelist=[500, 502, 503, 504, 104],
-            )
-        ),
+    adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=_UPLOAD_MAX_TRIES,
+            backoff_factor=_UPLOAD_RETRY_BACKOFF,
+            status_forcelist=[500, 502, 503, 504, 104],
+        )
     )
+    # Override longest-match adapter for http and https
+    session.mount("http://", adapter,)
+    session.mount("https://", adapter,)
     yield session
 
 

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -61,8 +61,14 @@ def requests_session():
         )
     )
     # Override longest-match adapter for http and https
-    session.mount("http://", adapter,)
-    session.mount("https://", adapter,)
+    session.mount(
+        "http://",
+        adapter,
+    )
+    session.mount(
+        "https://",
+        adapter,
+    )
     yield session
 
 


### PR DESCRIPTION
Fix diagnostics retry in integration tests, e.g. failure [here](https://buildkite.com/batfish/pybatfish-pre-commit/builds/17462#4befaf69-1be7-4b86-b684-60e3fba2dfbe) occurred because an adapter with a longer prefix-match was found (default `https://` vs custom `http`).

Similar to the change in https://github.com/batfish/pybatfish/pull/655.
