### PR TITLE
examples: move undefined reference

### DIFF
--- a/docs/networks/example-bgp/configs/as2core2.cfg
+++ b/docs/networks/example-bgp/configs/as2core2.cfg
@@ -106,7 +106,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/networks/example/configs/as2core2.cfg
+++ b/docs/networks/example/configs/as2core2.cfg
@@ -106,7 +106,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/networks/failure-analysis/configs/sanfrancisco.cfg
+++ b/docs/networks/failure-analysis/configs/sanfrancisco.cfg
@@ -106,7 +106,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/networks/forwarding-change-validation/base/configs/core2.cfg
+++ b/docs/networks/forwarding-change-validation/base/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/networks/forwarding-change-validation/change1-fixed/configs/core2.cfg
+++ b/docs/networks/forwarding-change-validation/change1-fixed/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/networks/forwarding-change-validation/change1/configs/core2.cfg
+++ b/docs/networks/forwarding-change-validation/change1/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/networks/forwarding-change-validation/change2-fixed/configs/core2.cfg
+++ b/docs/networks/forwarding-change-validation/change2-fixed/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/networks/forwarding-change-validation/change2/configs/core2.cfg
+++ b/docs/networks/forwarding-change-validation/change2/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/docs/source/notebooks/configProperties.ipynb
+++ b/docs/source/notebooks/configProperties.ipynb
@@ -4,9 +4,24 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:55.107861Z",
+     "iopub.status.busy": "2020-12-23T01:05:55.106426Z",
+     "iopub.status.idle": "2020-12-23T01:05:55.943128Z",
+     "shell.execute_reply": "2020-12-23T01:05:55.943749Z"
+    },
     "nbsphinx": "hidden"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/dan/.pyenv/versions/3.7.7/envs/pybf/lib/python3.7/site-packages/ipykernel_launcher.py:9: FutureWarning: Passing a negative integer is deprecated in version 1.0 and will not be supported in future version. Instead, use None to not limit the column width.\n",
+      "  if __name__ == '__main__':\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "from pybatfish.client.commands import *\n",
@@ -27,6 +42,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:55.948673Z",
+     "iopub.status.busy": "2020-12-23T01:05:55.947909Z",
+     "iopub.status.idle": "2020-12-23T01:05:55.950137Z",
+     "shell.execute_reply": "2020-12-23T01:05:55.950750Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [],
@@ -38,6 +59,12 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:55.955480Z",
+     "iopub.status.busy": "2020-12-23T01:05:55.954703Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.057117Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.057740Z"
+    },
     "nbsphinx": "hidden",
     "pycharm": {
      "name": "#%%\n"
@@ -82,6 +109,12 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.063859Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.062886Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.077476Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.078039Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -91,7 +124,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -104,6 +137,12 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.084584Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.083163Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.091436Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.092009Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -113,7 +152,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -170,7 +209,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.099483Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.098666Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.267431Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.268442Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.nodeProperties().answer().frame()"
@@ -235,7 +281,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.283287Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.281909Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.346798Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.347400Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -439,7 +492,7 @@
        "[5 rows x 34 columns]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -458,7 +511,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.354830Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.353413Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.373763Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.374939Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -500,7 +560,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -513,6 +573,12 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.382016Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.380632Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.391017Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.391727Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -522,7 +588,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -535,6 +601,12 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.403582Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.402364Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.412925Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.413740Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -544,7 +616,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -603,7 +675,14 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.421226Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.420161Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.614630Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.615642Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.interfaceProperties().answer().frame()"
@@ -669,7 +748,14 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.649903Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.648660Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.652839Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.653830Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -859,7 +945,7 @@
        "[5 rows x 35 columns]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -878,7 +964,14 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.664145Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.662830Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.667204Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.668192Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -921,7 +1014,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -934,6 +1027,12 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.674417Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.671506Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.681595Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.682254Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -943,7 +1042,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -956,6 +1055,12 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.688020Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.685076Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.696285Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.696960Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -965,7 +1070,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1022,7 +1127,14 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.704134Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.701758Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.839039Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.839629Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.bgpProcessConfiguration().answer().frame()"
@@ -1064,7 +1176,14 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.858405Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.857449Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.861131Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.861706Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1184,7 +1303,7 @@
        "4  as3core1    default  3.10.1.1  None             None                  True           True           EXACT_PATH           ['3.1.1.1/32', '3.2.2.2/32']                   True            ARRIVAL_ORDER"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1203,7 +1322,14 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.868613Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.867360Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.871135Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.871748Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1222,7 +1348,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1235,6 +1361,12 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.876874Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.875814Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.884283Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.884910Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -1244,7 +1376,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1257,6 +1389,12 @@
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.890719Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.889867Z",
+     "iopub.status.idle": "2020-12-23T01:05:56.898325Z",
+     "shell.execute_reply": "2020-12-23T01:05:56.898912Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -1266,7 +1404,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1323,7 +1461,14 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:56.906056Z",
+     "iopub.status.busy": "2020-12-23T01:05:56.905048Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.042368Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.043018Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.bgpPeerConfiguration().answer().frame()"
@@ -1370,7 +1515,14 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.064823Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.063752Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.067217Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.067775Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1520,7 +1672,7 @@
        "4  as2core1    default  2        2.1.2.1     None            None          2         2.1.3.2     None        True                   2.1.2.1    as2        []              []              True           False    "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1539,7 +1691,14 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.074426Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.073585Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.076675Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.077231Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1563,7 +1722,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1576,6 +1735,12 @@
    "cell_type": "code",
    "execution_count": 24,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.083222Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.082363Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.088844Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.089455Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -1585,7 +1750,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1598,6 +1763,12 @@
    "cell_type": "code",
    "execution_count": 25,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.095238Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.094235Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.103076Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.103903Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -1607,7 +1778,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1664,7 +1835,14 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.112019Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.111028Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.246145Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.246862Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.ospfProcessConfiguration().answer().frame()"
@@ -1703,7 +1881,14 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.264102Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.262851Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.266632Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.267391Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1805,7 +1990,7 @@
        "4  as1border2  default  1          ['1']  1e+08               1.2.2.2   []                    False            "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1824,7 +2009,14 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.274395Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.273580Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.276795Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.277508Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1840,7 +2032,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1853,6 +2045,12 @@
    "cell_type": "code",
    "execution_count": 29,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.283228Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.282312Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.289667Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.290305Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -1862,7 +2060,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1875,6 +2073,12 @@
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.295821Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.294952Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.302782Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.303440Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -1884,7 +2088,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1941,7 +2145,14 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.310579Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.309465Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.442406Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.443382Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.ospfInterfaceConfiguration().answer().frame()"
@@ -1982,7 +2193,14 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.458856Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.448785Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.463001Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.463605Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2096,7 +2314,7 @@
        "4  as3core1[GigabitEthernet1/0]  default  1          1              True         False        1         BROADCAST         10                  40               "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2115,7 +2333,14 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.470767Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.469580Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.473502Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.474083Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2133,7 +2358,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2146,6 +2371,12 @@
    "cell_type": "code",
    "execution_count": 34,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.480152Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.479272Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.487125Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.487769Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2155,7 +2386,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2168,6 +2399,12 @@
    "cell_type": "code",
    "execution_count": 35,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.493552Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.492683Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.500982Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.501565Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2177,7 +2414,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2233,7 +2470,14 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.509322Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.508317Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.647047Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.647799Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.ospfAreaConfiguration().answer().frame()"
@@ -2271,7 +2515,14 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.664697Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.663644Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.667872Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.668552Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2367,7 +2618,7 @@
        "4  as1border2  default  1          1    NONE      ['GigabitEthernet1/0', 'Loopback0']                                                                    []               "
       ]
      },
-     "execution_count": 37,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2386,7 +2637,14 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.676060Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.675022Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.679094Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.679676Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2401,7 +2659,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2414,6 +2672,12 @@
    "cell_type": "code",
    "execution_count": 39,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.687114Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.684980Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.692996Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.693586Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2423,7 +2687,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2436,6 +2700,12 @@
    "cell_type": "code",
    "execution_count": 40,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.700649Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.699083Z",
+     "iopub.status.idle": "2020-12-23T01:05:57.708641Z",
+     "shell.execute_reply": "2020-12-23T01:05:57.709339Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2445,7 +2715,7 @@
        "'aristaevpn'"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2502,7 +2772,14 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:57.717976Z",
+     "iopub.status.busy": "2020-12-23T01:05:57.716672Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.011374Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.012529Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.mlagProperties().answer().frame()"
@@ -2538,7 +2815,14 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.024915Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.023907Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.027691Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.028377Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2622,7 +2906,7 @@
        "4  dc1-l2leaf6a  DC1_L2LEAF6  10.255.252.23  dc1-l2leaf6a[Port-Channel3]  dc1-l2leaf6a[Vlan4094]"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2641,7 +2925,14 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.034906Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.034003Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.037397Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.038042Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2654,7 +2945,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2667,6 +2958,12 @@
    "cell_type": "code",
    "execution_count": 44,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.044219Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.043163Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.051109Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.051671Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2676,7 +2973,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2689,6 +2986,12 @@
    "cell_type": "code",
    "execution_count": 45,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.057645Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.056777Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.065280Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.065866Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2698,7 +3001,7 @@
        "'f5'"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2754,7 +3057,14 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.072390Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.071422Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.212476Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.213070Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.f5BigipVipConfiguration().answer().frame()"
@@ -2790,7 +3100,14 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.228149Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.226711Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.231010Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.231594Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2856,7 +3173,7 @@
        "2  f5bigip  /Common/virtual3  192.0.2.3:80 TCP  ['10.0.0.4:80', '10.0.0.3:80']                  "
       ]
      },
-     "execution_count": 47,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2875,7 +3192,14 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.238691Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.237621Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.241219Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.241832Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2888,7 +3212,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2901,6 +3225,12 @@
    "cell_type": "code",
    "execution_count": 49,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.247515Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.246127Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.254203Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.254797Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2910,7 +3240,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2923,6 +3253,12 @@
    "cell_type": "code",
    "execution_count": 50,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.260629Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.259387Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.269301Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.269872Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -2932,7 +3268,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2988,7 +3324,14 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.277324Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.276190Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.421273Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.421891Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.ipOwners().answer().frame()"
@@ -3025,7 +3368,14 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.434806Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.433846Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.437556Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.438138Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3115,7 +3465,7 @@
        "4  as3border2  default  GigabitEthernet1/0  3.0.2.1     24   True "
       ]
      },
-     "execution_count": 52,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3134,7 +3484,14 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.444906Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.443915Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.447556Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.448144Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3148,7 +3505,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3161,6 +3518,12 @@
    "cell_type": "code",
    "execution_count": 54,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.454203Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.452660Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.461101Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.461696Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3170,7 +3533,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3183,6 +3546,12 @@
    "cell_type": "code",
    "execution_count": 55,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.466678Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.465667Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.475586Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.476215Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3192,7 +3561,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3252,7 +3621,14 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.483173Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.481922Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.801605Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.802223Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.namedStructures().answer().frame()"
@@ -3287,7 +3663,14 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.833708Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.832308Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.837544Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.838427Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3372,7 +3755,7 @@
        "4  {'name': 'default', 'ospfProcesses': {'1': {'adminCosts': {'ospf': 110, 'ospfE1': 110, 'ospfE2': 110, 'ospfIA': 110}, 'areas': {'1': {'injectDefaultRoute': True, 'interfaces': ['GigabitEthernet0/0', 'GigabitEthernet1/0', 'Loopback0'], 'metricOfDefaultRoute': 0, 'name': 1, 'stubType': 'NONE'}}, 'exportPolicy': '~OSPF_EXPORT_POLICY:default~', 'processId': '1', 'referenceBandwidth': 100000000.0, 'routerId': '1.10.1.1', 'summaryAdminCost': 254}}, 'bgpProcess': {'ebgpAdminCost': 20, 'ibgpAdminCost': 200, 'routerId': '1.10.1.1', 'clusterListAsIgpCost': False, 'multipathEbgp': True, 'multipathEquivalentAsPathMatchMode': 'EXACT_PATH', 'multipathIbgp': True, 'neighbors': {'1.1.1.1/32': {'class': 'org.batfish.datamodel.BgpActivePeerConfig', 'clusterId': 17432833, 'defaultMetric': 0, 'ebgpMultihop': False, 'enforceFirstAs': True, 'group': 'as1', 'ipv4UnicastAddressFamily': {'addressFamilyCapabilities': {'additionalPathsReceive': True, 'additionalPathsSelectAll': True, 'additionalPathsSend': True, 'advertiseExternal': False, 'advertiseInactive': True, 'allowLocalAsIn': False, 'allowRemoteAsOut': True, 'sendCommunity': True, 'sendExtendedCommunity': False}, 'exportPolicy': '~BGP_PEER_EXPORT_POLICY:default:1.1.1.1~', 'routeReflectorClient': True}, 'localAs': 1, 'localIp': '1.10.1.1', 'peerAddress': '1.1.1.1', 'remoteAsns': '1'}, '1.2.2.2/32': {'class': 'org.batfish.datamodel.BgpActivePeerConfig', 'clusterId': 17432833, 'defaultMetric': 0, 'ebgpMultihop': False, 'enforceFirstAs': True, 'group': 'as1', 'ipv4UnicastAddressFamily': {'addressFamilyCapabilities': {'additionalPathsReceive': True, 'additionalPathsSelectAll': True, 'additionalPathsSend': True, 'advertiseExternal': False, 'advertiseInactive': True, 'allowLocalAsIn': False, 'allowRemoteAsOut': True, 'sendCommunity': True, 'sendExtendedCommunity': False}, 'exportPolicy': '~BGP_PEER_EXPORT_POLICY:default:1.2.2.2~', 'routeReflectorClient': True}, 'localAs': 1, 'localIp': '1.10.1.1', 'peerAddress': '1.2.2.2', 'remoteAsns': '1'}}, 'tieBreaker': 'ARRIVAL_ORDER'}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  "
       ]
      },
-     "execution_count": 57,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3391,7 +3774,14 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.846941Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.845659Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.850859Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.852142Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3403,7 +3793,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3416,6 +3806,12 @@
    "cell_type": "code",
    "execution_count": 59,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.857432Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.856288Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.864097Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.864696Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3425,7 +3821,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3438,6 +3834,12 @@
    "cell_type": "code",
    "execution_count": 60,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.870615Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.869609Z",
+     "iopub.status.idle": "2020-12-23T01:05:58.877807Z",
+     "shell.execute_reply": "2020-12-23T01:05:58.878395Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3447,7 +3849,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3506,7 +3908,14 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:58.887662Z",
+     "iopub.status.busy": "2020-12-23T01:05:58.886568Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.059357Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.060452Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.definedStructures().answer().frame()"
@@ -3540,7 +3949,14 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.075764Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.074431Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.079872Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.080838Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3612,7 +4028,7 @@
        "4  extended ipv4 access-list  101                 configs/as2border2.cfg:[140, 141]"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3631,7 +4047,14 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.090125Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.088888Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.099661Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.100848Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3642,7 +4065,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3655,6 +4078,12 @@
    "cell_type": "code",
    "execution_count": 64,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.109829Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.108302Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.118450Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.119895Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3664,7 +4093,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3677,6 +4106,12 @@
    "cell_type": "code",
    "execution_count": 65,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.128361Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.126874Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.138108Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.139196Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3686,7 +4121,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3744,7 +4179,14 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.153617Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.152072Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.322838Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.321928Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.referencedStructures().answer().frame()"
@@ -3779,7 +4221,14 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.339128Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.337809Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.342644Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.343577Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3857,7 +4306,7 @@
        "4  community-list  as2_community  route-map match community-list  configs/as1border1.cfg:[154]"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3876,7 +4325,14 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.352936Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.351318Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.355637Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.356220Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3888,7 +4344,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3901,6 +4357,12 @@
    "cell_type": "code",
    "execution_count": 69,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.362692Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.361552Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.369767Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.370360Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3910,7 +4372,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3923,6 +4385,12 @@
    "cell_type": "code",
    "execution_count": 70,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.379326Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.375449Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.384390Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.384985Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -3932,7 +4400,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3988,7 +4456,14 @@
   {
    "cell_type": "code",
    "execution_count": 71,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.391948Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.390685Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.541631Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.542647Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.undefinedReferences().answer().frame()"
@@ -4024,7 +4499,14 @@
   {
    "cell_type": "code",
    "execution_count": 72,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.564602Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.563306Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.570021Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.570978Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4061,7 +4543,7 @@
        "      <td>route-map</td>\n",
        "      <td>filter-bogons</td>\n",
        "      <td>bgp inbound route-map</td>\n",
-       "      <td>configs/as2core2.cfg:[109]</td>\n",
+       "      <td>configs/as2core2.cfg:[110]</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4069,10 +4551,10 @@
       ],
       "text/plain": [
        "              File_Name Struct_Type       Ref_Name                Context                       Lines\n",
-       "0  configs/as2core2.cfg  route-map   filter-bogons  bgp inbound route-map  configs/as2core2.cfg:[109]"
+       "0  configs/as2core2.cfg  route-map   filter-bogons  bgp inbound route-map  configs/as2core2.cfg:[110]"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4091,7 +4573,14 @@
   {
    "cell_type": "code",
    "execution_count": 73,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.583300Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.581079Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.587707Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.590411Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4100,11 +4589,11 @@
        "Struct_Type    route-map                 \n",
        "Ref_Name       filter-bogons             \n",
        "Context        bgp inbound route-map     \n",
-       "Lines          configs/as2core2.cfg:[109]\n",
+       "Lines          configs/as2core2.cfg:[110]\n",
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4117,6 +4606,12 @@
    "cell_type": "code",
    "execution_count": 74,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.599287Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.597051Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.603873Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.604537Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -4126,7 +4621,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4139,6 +4634,12 @@
    "cell_type": "code",
    "execution_count": 75,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.611373Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.609179Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.618291Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.618875Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -4148,7 +4649,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4204,7 +4705,14 @@
   {
    "cell_type": "code",
    "execution_count": 76,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.627181Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.625806Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.764201Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.764794Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.unusedStructures().answer().frame()"
@@ -4238,7 +4746,14 @@
   {
    "cell_type": "code",
    "execution_count": 77,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.770986Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.768379Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.778752Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.779465Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4310,7 +4825,7 @@
        "4  expanded community-list  as1_community         configs/as1border2.cfg:[123]     "
       ]
      },
-     "execution_count": 77,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4329,7 +4844,14 @@
   {
    "cell_type": "code",
    "execution_count": 78,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.786110Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.785198Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.788516Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.789074Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4340,7 +4862,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4353,6 +4875,12 @@
    "cell_type": "code",
    "execution_count": 79,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.794631Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.793754Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.800292Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.800916Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -4362,7 +4890,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4375,6 +4903,12 @@
    "cell_type": "code",
    "execution_count": 80,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.806338Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.805491Z",
+     "iopub.status.idle": "2020-12-23T01:05:59.813245Z",
+     "shell.execute_reply": "2020-12-23T01:05:59.813819Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -4384,7 +4918,7 @@
        "'aristaevpn'"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4443,7 +4977,14 @@
   {
    "cell_type": "code",
    "execution_count": 81,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:05:59.821002Z",
+     "iopub.status.busy": "2020-12-23T01:05:59.820081Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.048316Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.049058Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.switchedVlanProperties().answer().frame()"
@@ -4478,7 +5019,14 @@
   {
    "cell_type": "code",
    "execution_count": 82,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:06:03.062543Z",
+     "iopub.status.busy": "2020-12-23T01:06:03.061665Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.064974Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.065599Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4556,7 +5104,7 @@
        "4  dc1-leaf2b  3789    [dc1-leaf2b[Port-Channel3]]                   None    "
       ]
      },
-     "execution_count": 82,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4575,7 +5123,14 @@
   {
    "cell_type": "code",
    "execution_count": 83,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:06:03.071862Z",
+     "iopub.status.busy": "2020-12-23T01:06:03.070951Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.073989Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.074544Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4587,7 +5142,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4600,6 +5155,12 @@
    "cell_type": "code",
    "execution_count": 84,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:06:03.080029Z",
+     "iopub.status.busy": "2020-12-23T01:06:03.079184Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.086675Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.087239Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -4609,7 +5170,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4622,6 +5183,12 @@
    "cell_type": "code",
    "execution_count": 85,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:06:03.092511Z",
+     "iopub.status.busy": "2020-12-23T01:06:03.091356Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.100499Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.101097Z"
+    },
     "nbsphinx": "hidden"
    },
    "outputs": [
@@ -4631,7 +5198,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4690,7 +5257,14 @@
   {
    "cell_type": "code",
    "execution_count": 86,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:06:03.109176Z",
+     "iopub.status.busy": "2020-12-23T01:06:03.108007Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.422673Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.423680Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result = bfq.interfaceMtu(mtuBytes=2000, comparator='<').answer().frame()"
@@ -4723,7 +5297,14 @@
   {
    "cell_type": "code",
    "execution_count": 87,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:06:03.444810Z",
+     "iopub.status.busy": "2020-12-23T01:06:03.443921Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.447167Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.447729Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4789,7 +5370,7 @@
        "4  as1border2[Ethernet0/0]         1500"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4808,7 +5389,14 @@
   {
    "cell_type": "code",
    "execution_count": 88,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-12-23T01:06:03.454244Z",
+     "iopub.status.busy": "2020-12-23T01:06:03.453251Z",
+     "iopub.status.idle": "2020-12-23T01:06:03.456909Z",
+     "shell.execute_reply": "2020-12-23T01:06:03.456363Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4818,7 +5406,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/jupyter_notebooks/Getting started with Batfish.ipynb
+++ b/jupyter_notebooks/Getting started with Batfish.ipynb
@@ -22,10 +22,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:32.987871Z",
-     "iopub.status.busy": "2020-11-11T04:26:32.986831Z",
-     "iopub.status.idle": "2020-11-11T04:26:33.743370Z",
-     "shell.execute_reply": "2020-11-11T04:26:33.743944Z"
+     "iopub.execute_input": "2020-12-23T01:03:56.089124Z",
+     "iopub.status.busy": "2020-12-23T01:03:56.088130Z",
+     "iopub.status.idle": "2020-12-23T01:03:56.969199Z",
+     "shell.execute_reply": "2020-12-23T01:03:56.970791Z"
     }
    },
    "outputs": [],
@@ -47,10 +47,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:33.749576Z",
-     "iopub.status.busy": "2020-11-11T04:26:33.748775Z",
-     "iopub.status.idle": "2020-11-11T04:26:34.724281Z",
-     "shell.execute_reply": "2020-11-11T04:26:34.725019Z"
+     "iopub.execute_input": "2020-12-23T01:03:56.989713Z",
+     "iopub.status.busy": "2020-12-23T01:03:56.988237Z",
+     "iopub.status.idle": "2020-12-23T01:03:58.338699Z",
+     "shell.execute_reply": "2020-12-23T01:03:58.339715Z"
     },
     "scrolled": false
    },
@@ -103,10 +103,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:34.732868Z",
-     "iopub.status.busy": "2020-11-11T04:26:34.731712Z",
-     "iopub.status.idle": "2020-11-11T04:26:34.940074Z",
-     "shell.execute_reply": "2020-11-11T04:26:34.940739Z"
+     "iopub.execute_input": "2020-12-23T01:03:58.387307Z",
+     "iopub.status.busy": "2020-12-23T01:03:58.381705Z",
+     "iopub.status.idle": "2020-12-23T01:03:59.017624Z",
+     "shell.execute_reply": "2020-12-23T01:03:59.019476Z"
     }
    },
    "outputs": [],
@@ -143,10 +143,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:34.947028Z",
-     "iopub.status.busy": "2020-11-11T04:26:34.946243Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.075320Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.076038Z"
+     "iopub.execute_input": "2020-12-23T01:03:59.032954Z",
+     "iopub.status.busy": "2020-12-23T01:03:59.031516Z",
+     "iopub.status.idle": "2020-12-23T01:03:59.248120Z",
+     "shell.execute_reply": "2020-12-23T01:03:59.249392Z"
     }
    },
    "outputs": [],
@@ -168,10 +168,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.087695Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.086855Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.097672Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.098293Z"
+     "iopub.execute_input": "2020-12-23T01:03:59.273315Z",
+     "iopub.status.busy": "2020-12-23T01:03:59.258709Z",
+     "iopub.status.idle": "2020-12-23T01:03:59.348135Z",
+     "shell.execute_reply": "2020-12-23T01:03:59.349575Z"
     }
    },
    "outputs": [
@@ -351,10 +351,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.106067Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.105232Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.108265Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.108840Z"
+     "iopub.execute_input": "2020-12-23T01:03:59.368934Z",
+     "iopub.status.busy": "2020-12-23T01:03:59.367557Z",
+     "iopub.status.idle": "2020-12-23T01:03:59.374445Z",
+     "shell.execute_reply": "2020-12-23T01:03:59.376097Z"
     }
    },
    "outputs": [
@@ -410,10 +410,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.114661Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.113870Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.244358Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.244946Z"
+     "iopub.execute_input": "2020-12-23T01:03:59.387452Z",
+     "iopub.status.busy": "2020-12-23T01:03:59.386202Z",
+     "iopub.status.idle": "2020-12-23T01:03:59.559726Z",
+     "shell.execute_reply": "2020-12-23T01:03:59.561394Z"
     }
    },
    "outputs": [
@@ -485,10 +485,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.251681Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.250842Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.393180Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.393882Z"
+     "iopub.execute_input": "2020-12-23T01:03:59.583978Z",
+     "iopub.status.busy": "2020-12-23T01:03:59.580696Z",
+     "iopub.status.idle": "2020-12-23T01:03:59.799419Z",
+     "shell.execute_reply": "2020-12-23T01:03:59.802341Z"
     }
    },
    "outputs": [],
@@ -502,10 +502,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.399847Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.398906Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.402117Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.402822Z"
+     "iopub.execute_input": "2020-12-23T01:03:59.812569Z",
+     "iopub.status.busy": "2020-12-23T01:03:59.810986Z",
+     "iopub.status.idle": "2020-12-23T01:03:59.822854Z",
+     "shell.execute_reply": "2020-12-23T01:03:59.825636Z"
     }
    },
    "outputs": [
@@ -541,10 +541,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.410937Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.409981Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.551000Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.551611Z"
+     "iopub.execute_input": "2020-12-23T01:03:59.838776Z",
+     "iopub.status.busy": "2020-12-23T01:03:59.833865Z",
+     "iopub.status.idle": "2020-12-23T01:04:00.024031Z",
+     "shell.execute_reply": "2020-12-23T01:04:00.025693Z"
     }
    },
    "outputs": [
@@ -672,10 +672,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.563472Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.562670Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.565556Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.566157Z"
+     "iopub.execute_input": "2020-12-23T01:04:00.052162Z",
+     "iopub.status.busy": "2020-12-23T01:04:00.050219Z",
+     "iopub.status.idle": "2020-12-23T01:04:00.060045Z",
+     "shell.execute_reply": "2020-12-23T01:04:00.061222Z"
     }
    },
    "outputs": [
@@ -780,10 +780,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.576758Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.575920Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.578871Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.579460Z"
+     "iopub.execute_input": "2020-12-23T01:04:00.080468Z",
+     "iopub.status.busy": "2020-12-23T01:04:00.078774Z",
+     "iopub.status.idle": "2020-12-23T01:04:00.088185Z",
+     "shell.execute_reply": "2020-12-23T01:04:00.089179Z"
     }
    },
    "outputs": [
@@ -873,10 +873,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.585822Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.584980Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.721584Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.722169Z"
+     "iopub.execute_input": "2020-12-23T01:04:00.100436Z",
+     "iopub.status.busy": "2020-12-23T01:04:00.098435Z",
+     "iopub.status.idle": "2020-12-23T01:04:00.300427Z",
+     "shell.execute_reply": "2020-12-23T01:04:00.301580Z"
     }
    },
    "outputs": [],
@@ -898,10 +898,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.732624Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.731803Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.734887Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.735481Z"
+     "iopub.execute_input": "2020-12-23T01:04:00.314150Z",
+     "iopub.status.busy": "2020-12-23T01:04:00.313179Z",
+     "iopub.status.idle": "2020-12-23T01:04:00.325802Z",
+     "shell.execute_reply": "2020-12-23T01:04:00.326785Z"
     }
    },
    "outputs": [
@@ -987,10 +987,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.742241Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.741388Z",
-     "iopub.status.idle": "2020-11-11T04:26:35.884757Z",
-     "shell.execute_reply": "2020-11-11T04:26:35.886025Z"
+     "iopub.execute_input": "2020-12-23T01:04:00.337736Z",
+     "iopub.status.busy": "2020-12-23T01:04:00.336423Z",
+     "iopub.status.idle": "2020-12-23T01:04:00.487828Z",
+     "shell.execute_reply": "2020-12-23T01:04:00.488901Z"
     }
    },
    "outputs": [
@@ -1029,7 +1029,7 @@
        "      <td>route-map</td>\n",
        "      <td>filter-bogons</td>\n",
        "      <td>bgp inbound route-map</td>\n",
-       "      <td>configs/as2core2.cfg:[109]</td>\n",
+       "      <td>configs/as2core2.cfg:[110]</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1040,7 +1040,7 @@
        "0  configs/as2core2.cfg   route-map  filter-bogons  bgp inbound route-map   \n",
        "\n",
        "                        Lines  \n",
-       "0  configs/as2core2.cfg:[109]  "
+       "0  configs/as2core2.cfg:[110]  "
       ]
      },
      "execution_count": 1,
@@ -1074,10 +1074,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:35.898813Z",
-     "iopub.status.busy": "2020-11-11T04:26:35.896423Z",
-     "iopub.status.idle": "2020-11-11T04:26:36.202669Z",
-     "shell.execute_reply": "2020-11-11T04:26:36.203646Z"
+     "iopub.execute_input": "2020-12-23T01:04:00.499476Z",
+     "iopub.status.busy": "2020-12-23T01:04:00.497520Z",
+     "iopub.status.idle": "2020-12-23T01:04:01.044710Z",
+     "shell.execute_reply": "2020-12-23T01:04:01.046008Z"
     }
    },
    "outputs": [
@@ -1163,10 +1163,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:36.215489Z",
-     "iopub.status.busy": "2020-11-11T04:26:36.213551Z",
-     "iopub.status.idle": "2020-11-11T04:26:36.539377Z",
-     "shell.execute_reply": "2020-11-11T04:26:36.540101Z"
+     "iopub.execute_input": "2020-12-23T01:04:01.058809Z",
+     "iopub.status.busy": "2020-12-23T01:04:01.057477Z",
+     "iopub.status.idle": "2020-12-23T01:04:01.243173Z",
+     "shell.execute_reply": "2020-12-23T01:04:01.244467Z"
     }
    },
    "outputs": [
@@ -1222,10 +1222,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:36.548452Z",
-     "iopub.status.busy": "2020-11-11T04:26:36.547361Z",
-     "iopub.status.idle": "2020-11-11T04:26:36.718410Z",
-     "shell.execute_reply": "2020-11-11T04:26:36.719295Z"
+     "iopub.execute_input": "2020-12-23T01:04:01.254879Z",
+     "iopub.status.busy": "2020-12-23T01:04:01.253443Z",
+     "iopub.status.idle": "2020-12-23T01:04:01.471125Z",
+     "shell.execute_reply": "2020-12-23T01:04:01.472462Z"
     }
    },
    "outputs": [],
@@ -1248,10 +1248,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-11T04:26:36.737026Z",
-     "iopub.status.busy": "2020-11-11T04:26:36.735884Z",
-     "iopub.status.idle": "2020-11-11T04:26:36.739701Z",
-     "shell.execute_reply": "2020-11-11T04:26:36.740413Z"
+     "iopub.execute_input": "2020-12-23T01:04:01.497818Z",
+     "iopub.status.busy": "2020-12-23T01:04:01.496444Z",
+     "iopub.status.idle": "2020-12-23T01:04:01.501770Z",
+     "shell.execute_reply": "2020-12-23T01:04:01.502671Z"
     }
    },
    "outputs": [
@@ -1375,7 +1375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/jupyter_notebooks/networks/example-bgp/configs/as2core2.cfg
+++ b/jupyter_notebooks/networks/example-bgp/configs/as2core2.cfg
@@ -106,7 +106,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/jupyter_notebooks/networks/example/configs/as2core2.cfg
+++ b/jupyter_notebooks/networks/example/configs/as2core2.cfg
@@ -106,7 +106,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/jupyter_notebooks/networks/failure-analysis/configs/sanfrancisco.cfg
+++ b/jupyter_notebooks/networks/failure-analysis/configs/sanfrancisco.cfg
@@ -106,7 +106,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/jupyter_notebooks/networks/forwarding-change-validation/base/configs/core2.cfg
+++ b/jupyter_notebooks/networks/forwarding-change-validation/base/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/jupyter_notebooks/networks/forwarding-change-validation/change1-fixed/configs/core2.cfg
+++ b/jupyter_notebooks/networks/forwarding-change-validation/change1-fixed/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/jupyter_notebooks/networks/forwarding-change-validation/change1/configs/core2.cfg
+++ b/jupyter_notebooks/networks/forwarding-change-validation/change1/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/jupyter_notebooks/networks/forwarding-change-validation/change2-fixed/configs/core2.cfg
+++ b/jupyter_notebooks/networks/forwarding-change-validation/change2-fixed/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate

--- a/jupyter_notebooks/networks/forwarding-change-validation/change2/configs/core2.cfg
+++ b/jupyter_notebooks/networks/forwarding-change-validation/change2/configs/core2.cfg
@@ -110,7 +110,8 @@ router bgp 2
   neighbor as2 send-community
   neighbor as2 route-reflector-client
   neighbor as2 advertise additional-paths all
-  neighbor as2 route-map filter-bogons in
+  neighbor as3 peer-group
+  neighbor as3 route-map filter-bogons in
   neighbor 2.1.1.1 activate
   neighbor 2.1.1.2 activate
   neighbor 2.1.3.1 activate


### PR DESCRIPTION
Future work in batfish will make these undefined references impact routing. Before that
happens, preserve undefined references AND routing behavior by adding a unused, undefined
reference.