### PR TITLE
Unpin docutils from docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,3 @@ progressbar2==3.47.0
 recommonmark==0.6.0
 sphinx==2.3.1
 sphinx-notfound-page==0.4
-docutils==0.16  # https://github.com/spatialaudio/nbsphinx/issues/549


### PR DESCRIPTION
The issue that caused the pin (https://github.com/spatialaudio/nbsphinx/issues/549) in #722 is resolved. 

Pinning was causing doc building to fail (#726). 