### PR TITLE
CI: black requires we use C.UTF-8 encoding

### DIFF
--- a/fix_format.sh
+++ b/fix_format.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Black will crash if we use ASCII:
+# https://click.palletsprojects.com/en/8.0.x/unicode-support/
+# TODO: is there a better place to do this?
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
 args=""
 if [[ ${1-} == '-c' ]] || [[ ${1-} == '--check' ]]; then
   args="${args} --check"


### PR DESCRIPTION
Fix CI failures like this:
https://buildkite.com/batfish/pybatfish-pre-commit/builds/21575#b76894ea-1cae-4eb7-ac7a-1565d916fe4c/101-143

I'm just following the recommendation from the error message. Maybe there's a better way (or place?) to do this.

More info: https://click.palletsprojects.com/en/8.0.x/unicode-support/