### PR TITLE
Pin docutils for proper bulleted lists

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -31,6 +31,7 @@ dependencies:
     - decorator==4.4.1
     - deepdiff==4.0.9
     - defusedxml==0.6.0
+    - docutils==0.16 # don't upgrade: https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
     - entrypoints==0.3
     - idna==2.8
     - imagesize==1.2.0


### PR DESCRIPTION
The bulleted lists were not rendering properly because of latest docutils

Before: 

<img width="809" alt="Screen Shot 2021-10-17 at 10 19 11 PM" src="https://user-images.githubusercontent.com/4723124/137673285-61a8408c-7c5e-4017-b055-ad8ab6b6894d.png">

After:

<img width="702" alt="Screen Shot 2021-10-17 at 10 19 42 PM" src="https://user-images.githubusercontent.com/4723124/137673322-7628cc06-cfe8-4675-a1c7-1a5e4c33fbe8.png">
