### PR TITLE
Netconan: bump required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         "attrs>=18.1.0",
         "deepdiff",
         "deprecated",
-        "netconan>=0.11.0",
+        "netconan>=0.12.0",
         "pandas<1.2",
         "python-dateutil",
         "PyYAML",


### PR DESCRIPTION
Bump `netconan` version to `0.12` which, among other things, turns on the new `preserve-host-bits` feature.

----

This new feature preserves the last octet by default. See [the `preserve-host-bits` PR for more details](https://github.com/intentionet/netconan/pull/150), but before this feature, a link 10.0.0.1/30 and 10.0.0.2/30 will be broken 3/4 of the time because one of the IPs may get anonymized to 10.0.0.0 (the network address) or 10.0.0.3 (the broadcast address).

Similarly, with no order-preservation guarantees, things like IP ranges or NAT pools might have been anonymized in a way that the anonymized `end` address comes before the anonymized `start` address.
