### PR TITLE
Docs: Add newlines in Cumulus packaging

### DIFF
--- a/docs/source/formats.md
+++ b/docs/source/formats.md
@@ -121,14 +121,17 @@ hostname=$(cat /etc/hostname)
   # Signal start of /etc/network/interfaces
   echo "# This file describes the network interfaces"
   cat /etc/network/interfaces
+  echo 
 
   # Signal start of /etc/cumulus/ports.conf
   echo "# ports.conf --"
   cat /etc/cumulus/ports.conf
+  echo 
 
   # Signal start of /etc/frr/frr.conf
   echo "frr version"
   cat /etc/frr/frr.conf
+  echo
 ) > $hostname.cfg
 ```
 


### PR DESCRIPTION
Sometimes Cumulus files don't have a newline in the end, which mixes lines from two files. 