### PR TITLE
Update getting started instructions

### DIFF
--- a/docs/source/notebooks/interacting.ipynb
+++ b/docs/source/notebooks/interacting.ipynb
@@ -262,7 +262,7 @@
     "* `bf.q.<question_name>().answer()` sends the question to the Batfish service and returns the answer\n",
     "* `bf.q.<question_name>().answer().frame()` converts the answer into a [Pandas dataframe](https://pandas.pydata.org/pandas-docs/stable/getting_started/dsintro.html#dataframe) for easy data manipulation\n",
     "\n",
-    "This pattern is demonstrate via the `initIssues` question below. "
+    "This pattern is demonstrated via the `initIssues` question below. "
    ]
   },
   {
@@ -365,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Given the answer of a question, you may want to focus on certain rows/columns or ignore certain rows. This is easy via Pandas dataframe manipulation. For instance, if you want to ignore all rows that warn about update source, you may do the following."
+    "Given the answer of a question, you may want to focus on certain rows/columns or ignore certain rows. This is easy via Pandas dataframe manipulation. For instance, if you want to ignore all rows that warn about BGP update source, you may do the following."
    ]
   },
   {

--- a/docs/source/notebooks/interacting.ipynb
+++ b/docs/source/notebooks/interacting.ipynb
@@ -365,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Given the answer of a question, you may want to focus on certain rows/columns or ignore certain rows. This is easy via Pandas dataframe manipulation. For instance, if you want to ignore the first row above, you may do the following."
+    "Given the answer of a question, you may want to focus on certain rows/columns or ignore certain rows. This is easy via Pandas dataframe manipulation. For instance, if you want to ignore all rows that warn about update source, you may do the following."
    ]
   },
   {
@@ -403,28 +403,14 @@
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>['as1border1']</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Convert warning (redflag)</td>\n",
-       "      <td>Could not determine update source for BGP neighbor: '3.2.2.2'</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "            Nodes Source_Lines                       Type  \\\n",
-       "1  ['as1border1']         None  Convert warning (redflag)   \n",
-       "\n",
-       "                                                         Details Line_Text  \\\n",
-       "1  Could not determine update source for BGP neighbor: '3.2.2.2'      None   \n",
-       "\n",
-       "  Parser_Context  \n",
-       "1           None  "
+       "Empty DataFrame\n",
+       "Columns: [Nodes, Source_Lines, Type, Details, Line_Text, Parser_Context]\n",
+       "Index: []"
       ]
      },
      "execution_count": 9,
@@ -434,7 +420,7 @@
    ],
    "source": [
     "issues = bf.q.initIssues().answer().frame()\n",
-    "issues[issues['Details'].apply(lambda x: x != \"Could not determine update source for BGP neighbor: '5.6.7.8'\")]"
+    "issues[issues['Details'].apply(lambda x: \"Could not determine update source for BGP neighbor:\" not in x)]"
    ]
   },
   {

--- a/docs/source/notebooks/interacting.ipynb
+++ b/docs/source/notebooks/interacting.ipynb
@@ -124,7 +124,7 @@
        "'example_dc'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,7 +192,7 @@
        "'snapshot-2020-01-01'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -206,14 +206,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Using an existing snapshot"
+    "#### Analyzing an existing snapshot"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have a previously initialized snapshot that you would like to work with, you do not need to re-initialize it.\n",
+    "If you would like to analyze a previously-initialized snapshot, you do not need to re-initialize it.\n",
     "Simply set the network and snapshot by name:"
    ]
   },
@@ -228,7 +228,7 @@
        "'snapshot-2020-01-01'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -249,16 +249,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that you have initialized (or set) a snapshot, \n",
+    "After initializing (or setting) a snapshot, \n",
     "you can query the Batfish service to retrieve information about the snapshot.\n",
     "\n",
     "Batfish exposes a series of *questions* to users.\n",
     "With the help of these questions you can examine data about you network as a whole,\n",
-    "or individual devices, in a vendor-agnostic way.\n",
+    "or individual devices, in a vendor-agnostic way. \n",
     "\n",
-    "Note that while Batfish supports a wide variety of devices and configuration constructs, \n",
+    "The general pattern for Batfish questions is:\n",
+    "\n",
+    "* `bf.q.<question_name>()` Creates a question (with parameters, if applicable).\n",
+    "* `bf.q.<question_name>().answer()` sends the question to the Batfish service and returns the answer\n",
+    "* `bf.q.<question_name>().answer().frame()` converts the answer into a [Pandas dataframe](https://pandas.pydata.org/pandas-docs/stable/getting_started/dsintro.html#dataframe) for easy data manipulation\n",
+    "\n",
+    "This pattern is demonstrate via the `initIssues` question below. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Initialization issues"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While Batfish supports a wide variety of vendors and configuration constructs, \n",
     "it may not fully support your configuration files. \n",
-    "We always recommend checking the status of the snapshot you just initialized, by runnning `bf.q.initIssues`:"
+    "We recommend checking the status of the snapshot you just initialized, by runnning `bf.q.initIssues`:"
    ]
   },
   {
@@ -332,7 +352,7 @@
        "1           None  "
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -345,15 +365,83 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is the general pattern you will be using for many questions:\n",
-    "\n",
-    "* `bf.q.<question_name>()` Creates a question (with parameters, if applicable).\n",
-    "* `bf.q.<question_name>().answer()` sends a query to Batfish service and returns the results of executing the question\n",
-    "* `bf.q.<question_name>().answer().frame()` converts the answer into a [Pandas dataframe](https://pandas.pydata.org/pandas-docs/stable/getting_started/dsintro.html#dataframe) for easy data manipulation\n",
-    "\n",
-    "These are the very basics of how to interact with the Batfish service.\n",
-    "\n",
-    "As a next step, explore [a variety of questions](../questions.rst) that allow you to analyze your network in great detail."
+    "Given the answer of a question, you may want to focus on certain rows/columns or ignore certain rows. This is easy via Pandas dataframe manipulation. For instance, if you want to ignore the first row above, you may do the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe tex2jax_ignore\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Nodes</th>\n",
+       "      <th>Source_Lines</th>\n",
+       "      <th>Type</th>\n",
+       "      <th>Details</th>\n",
+       "      <th>Line_Text</th>\n",
+       "      <th>Parser_Context</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>['as1border1']</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Convert warning (redflag)</td>\n",
+       "      <td>Could not determine update source for BGP neighbor: '3.2.2.2'</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Nodes Source_Lines                       Type  \\\n",
+       "1  ['as1border1']         None  Convert warning (redflag)   \n",
+       "\n",
+       "                                                         Details Line_Text  \\\n",
+       "1  Could not determine update source for BGP neighbor: '3.2.2.2'      None   \n",
+       "\n",
+       "  Parser_Context  \n",
+       "1           None  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "issues = bf.q.initIssues().answer().frame()\n",
+    "issues[issues['Details'].apply(lambda x: x != \"Could not determine update source for BGP neighbor: '5.6.7.8'\")]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that you know the basics of interacting with the Batfish service, you can 1) explore [a variety of questions](../questions.rst) that enable you to analyze your network in great detail; and 2) check out [code examples](../public_notebooks.html) for a range of use cases. "
    ]
   },
   {
@@ -379,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/source/notebooks/interacting.ipynb
+++ b/docs/source/notebooks/interacting.ipynb
@@ -427,7 +427,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that you know the basics of interacting with the Batfish service, you can 1) explore [a variety of questions](../questions.rst) that enable you to analyze your network in great detail; and 2) check out [code examples](../public_notebooks.html) for a range of use cases. "
+    "Now that you know the basics of interacting with the Batfish service, you can 1) explore [a variety of questions](../questions.rst) that enable you to analyze your network in great detail; and 2) check out [code examples](../public_notebooks.rst) for a range of use cases. "
    ]
   },
   {


### PR DESCRIPTION
The primary change, besides minor cleanup, is to include a simple example of Pandas filtering on initIssues, to show a primary usage modality and to help users that get too many initIssues and then don't know how to ignore ones that don't matter as much. 