### PR TITLE
black: upgrade to latest, switch to official mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
     hooks:
     - id: check-yaml
 
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.11.0
     hooks:
     - id: black
 

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     extras_require={
         "capirca": CAPIRCA_DEPS,
         "dev": [
-            "black<23.8",
+            "black<23.11",
             "cerberus",
             "check-manifest",
             "coverage",


### PR DESCRIPTION
> Black now has an official pre-commit mirror. Swapping
> https://github.com/psf/black to https://github.com/psf/black-pre-commit-mirror
> in your .pre-commit-config.yaml will make Black about 2x faster (#3828)