### PR TITLE
test_[network,snapshot]_funcs: adjust requires_bf

### DIFF
--- a/tests/integration/test_network_funcs.py
+++ b/tests/integration/test_network_funcs.py
@@ -61,6 +61,7 @@ def test_list_incomplete_works(bf: Session) -> None:
         bf.delete_network(network)
 
 
+@requires_bf("2024.07.01")
 def test_delete_network_object(bf: Session, network: str) -> None:
     bf.put_network_object("new_object", "goodbye")
     bf.delete_network_object("new_object")
@@ -105,6 +106,7 @@ def test_add_node_roles_data(bf: Session) -> None:
         bf.delete_network(network_name)
 
 
+@requires_bf("2024.07.01")
 def test_get_network_object(bf: Session, network: str) -> None:
     # non-existent object should yield 404
     with raises(HTTPError, match="404"):

--- a/tests/integration/test_snapshot_funcs.py
+++ b/tests/integration/test_snapshot_funcs.py
@@ -211,6 +211,7 @@ def test_get_snapshot_inferred_node_roles(
     assert len(bf.get_node_roles(inferred=True).roleMappings) > 0
 
 
+@requires_bf("2024.07.01")
 def test_get_snapshot_input_object(
     bf: Session, network: str, example_snapshot: str
 ) -> None:
@@ -242,7 +243,7 @@ def test_get_snapshot_node_roles(
     assert snapshot_node_roles.roleDimensionOrder[0] == dimension_name
 
 
-@requires_bf("2019.10.28")
+@requires_bf("2024.07.01")
 def test_delete_snapshot_object(
     bf: Session, network: str, example_snapshot: str
 ) -> None:
@@ -257,6 +258,7 @@ def test_delete_snapshot_object(
         bf.get_snapshot_object_text("new_object")
 
 
+@requires_bf("2024.07.01")
 def test_get_snapshot_object(bf: Session, network: str, example_snapshot: str) -> None:
     bf.set_network(network)
     bf.set_snapshot(example_snapshot)


### PR DESCRIPTION
This is required since we moved to session-level functions after deleting the old
default session.