### PR TITLE
Remove netconan as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ setup(
     install_requires=[
         "attrs>=18.1.0",
         "deepdiff",
-        "netconan>=0.12.0",
         "pandas",
         "python-dateutil",
         "PyYAML",


### PR DESCRIPTION
No longer used. Last feature that used it was diagnostics, and that was removed in #909