### PR TITLE
Add readthedocs to precommit, fix build

### DIFF
--- a/.github/workflows/reusable-precommit.yml
+++ b/.github/workflows/reusable-precommit.yml
@@ -209,3 +209,22 @@ jobs:
         with:
           name: docs
           path: docs/build/html
+  readthedocs_build:
+    runs-on: ubuntu-22.04 # Match ReadTheDocs OS
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9 # Match ReadTheDocs Python version
+      - name: Build docs in ReadTheDocs-like environment
+        run: |
+          sudo apt update -qq
+          sudo apt -qq install -y pandoc
+          export READTHEDOCS_OUTPUT=../../RTDOUT
+          # The remaining commands are copied direct from readthedocs.org build logs
+          # We may need to update them if RTD changes what it does.
+          python -m pip install --upgrade --no-cache-dir pip setuptools
+          python -m pip install --upgrade --no-cache-dir sphinx
+          python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir .[dev]
+          cd docs/source ## This command is not copied, but it seems that RTD switches directories invisible at some point
+          python -m sphinx -T -W --keep-going -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,10 +16,6 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - htmlzip
-
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:


### PR DESCRIPTION
Sometime in October 2024, RTD made a breaking change and broke our build.

Last working: https://app.readthedocs.org/projects/pybatfish/builds/25850120/
First failing: https://app.readthedocs.org/projects/pybatfish/builds/25876957/

Many major version changes, etc.

It seems that the issue is related to the htmlzip build reusing some
intermediate state from the first build. If I manually only build one
OR the other, it works fine.

For now, disable the htmlzip build (html is required) to unblock.