### PR TITLE
pkg_resources to importlib.metadata conversion

### DIFF
--- a/pybatfish/client/session.py
+++ b/pybatfish/client/session.py
@@ -33,7 +33,6 @@ from typing import (  # noqa: F401
     Union,
 )
 
-import pkg_resources
 from requests import HTTPError
 
 from pybatfish.client import restv2helper, workhelper
@@ -391,10 +390,14 @@ class Session:
     @classmethod
     def get_session_types(cls) -> dict[str, Callable]:
         """Get a dict of possible session types mapping their names to session classes."""
-        return {
-            entry_point.name: entry_point.load()
-            for entry_point in pkg_resources.iter_entry_points("batfish_session")
-        }
+        import sys
+        from importlib.metadata import entry_points
+
+        if sys.version_info < (3, 10):
+            eps = entry_points().get("batfish_session", [])
+        else:
+            eps = entry_points(group="batfish_session")
+        return {ep.name: ep.load() for ep in eps}
 
     @classmethod
     def get(cls, type_: str = "bf", **params: Any) -> Session:


### PR DESCRIPTION
Removes this warning from 3.13 while keeping pybatfish working from 3.9 to 3.13. This is mildly annoying because 3.10 is where the entry_points API stabilized.

> pybatfish/client/session.py:36: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
