### PR TITLE
pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v6.0.0
     hooks:
     - id: check-yaml
 


### PR DESCRIPTION
Trying to fix https://github.com/batfish/pybatfish/actions/runs/17770189692/job/50503926845

```
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
Warning:  repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` will fix this.  if it does not -- consider reporting an issue to that repo.
[INFO] Initializing environment for https://github.com/psf/black-pre-commit-mirror.
[INFO] Initializing environment for https://github.com/pycqa/isort.
[INFO] Initializing environment for https://github.com/humitos/mirrors-autoflake.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
stdout: (none)
stderr:
fatal: could not read Username for 'https://github.com': No such device or address
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
```