### PR TITLE
Add Python 3.14 to test matrix and classifiers

### DIFF
--- a/.github/workflows/reusable-precommit.yml
+++ b/.github/workflows/reusable-precommit.yml
@@ -105,6 +105,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
   integration_tests:
     runs-on: ubuntu-latest
     needs:
@@ -153,6 +154,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
   doc_tests:
     runs-on: ubuntu-latest
     needs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 keywords = ["network", "configuration", "verification"]
 dependencies = [


### PR DESCRIPTION
Adds Python 3.14 support to CI test matrix and package classifiers.