### PR TITLE
Strip non-deterministic cell id fields from notebook test output

### DIFF
--- a/docs/nb_gen/gen_question_notebooks.py
+++ b/docs/nb_gen/gen_question_notebooks.py
@@ -235,9 +235,10 @@ def execute_notebook(nb: NotebookNode, name: str) -> NotebookNode:
     ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
     ep.preprocess(nb, {"metadata": {"path": _DOC_DIR}})
 
-    # Clear undesirable metadata from cells
+    # Clear undesirable metadata and non-deterministic fields from cells
     keep_metadata = {"nbsphinx"}
     for cell in nb.cells:
+        cell.pop("id", None)
         meta = cell.get("metadata", {})
         cell["metadata"] = {k: v for k, v in meta.items() if k in keep_metadata}
     return nb

--- a/docs/nb_gen_tests/test_notebook.py
+++ b/docs/nb_gen_tests/test_notebook.py
@@ -128,9 +128,10 @@ def rendered_nb(request: Any, categories: Mapping[str, Any], session: Session, s
     ep = ExecutePreprocessor(timeout=60, allow_errors=True, kernel_name="python3")
     ep.preprocess(nb_to_execute, resources={"metadata": {"path": exec_path}})
 
-    # Clear undesirable metadata from cells
+    # Clear undesirable metadata and non-deterministic fields from cells
     keep_metadata = {"nbsphinx"}
     for cell in nb_to_execute.cells:
+        cell.pop("id", None)
         if "metadata" not in cell:
             continue
         meta = cell["metadata"]

--- a/docs/source/notebooks/configProperties.ipynb
+++ b/docs/source/notebooks/configProperties.ipynb
@@ -36,7 +36,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8025d38",
    "metadata": {},
    "source": [
     "#### Configuration Properties"
@@ -44,7 +43,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88ff9716",
    "metadata": {},
    "source": [
     "This category of questions enables you to retrieve and process the\n",
@@ -55,7 +53,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9411255e",
    "metadata": {},
    "source": [
     "* [Node Properties](#Node-Properties)\n",
@@ -82,7 +79,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6544b393",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -105,7 +101,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "30731318",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -127,7 +122,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81f737ba",
    "metadata": {},
    "source": [
     "##### Node Properties"
@@ -135,7 +129,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c8ae053",
    "metadata": {},
    "source": [
     "Returns configuration settings of nodes."
@@ -143,7 +136,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c99336ed",
    "metadata": {},
    "source": [
     "Lists global settings of devices in the network. Settings that are specific to interfaces, routing protocols, etc. are available via other questions."
@@ -151,7 +143,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "880eccf7",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -159,7 +150,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ef1766d",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -170,7 +160,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe06ea06",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -179,7 +168,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0717f43a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +176,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7be61c9",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -196,7 +183,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "007ad8e0",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -242,7 +228,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40ac417e",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -251,7 +236,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "1dc8d7da",
    "metadata": {},
    "outputs": [
     {
@@ -534,7 +518,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adc156d7",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -543,7 +526,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1ca51885",
    "metadata": {},
    "outputs": [
     {
@@ -601,7 +583,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "0c861a38",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -624,7 +605,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "65485788",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -646,7 +626,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d63ec9e2",
    "metadata": {},
    "source": [
     "##### Interface Properties"
@@ -654,7 +633,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5186ff9e",
    "metadata": {},
    "source": [
     "Returns configuration settings of interfaces."
@@ -662,7 +640,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b19e44f",
    "metadata": {},
    "source": [
     "Lists interface-level settings of interfaces. Settings for routing protocols, VRFs, and zones etc. that are attached to interfaces are available via other questions."
@@ -670,7 +647,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45fb3e64",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -678,7 +654,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41834b87",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -691,7 +666,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe782325",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -700,7 +674,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a3668572",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,7 +682,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c35149b",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -717,7 +689,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6a825d2",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -763,7 +734,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "467fea33",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -772,7 +742,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "d9579225",
    "metadata": {},
    "outputs": [
     {
@@ -1034,7 +1003,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc38a145",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1043,7 +1011,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "90bbae71",
    "metadata": {},
    "outputs": [
     {
@@ -1101,7 +1068,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "1802f06c",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1124,7 +1090,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "ec3a5b3e",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1146,7 +1111,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "245ce59d",
    "metadata": {},
    "source": [
     "##### BGP Process Configuration"
@@ -1154,7 +1118,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daecff61",
    "metadata": {},
    "source": [
     "Returns configuration settings of BGP processes."
@@ -1162,7 +1125,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e27c4509",
    "metadata": {},
    "source": [
     "Reports configuration settings for each BGP process on each node and VRF in the network. This question reports only process-wide settings. Peer-specific settings are reported by the bgpPeerConfiguration question."
@@ -1170,7 +1132,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e102560",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1178,7 +1139,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22050c4c",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1189,7 +1149,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a436d1a",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1198,7 +1157,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "1c3e86f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1207,7 +1165,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1592b6bf",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1215,7 +1172,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e29cf336",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1235,7 +1191,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4e85367",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1244,7 +1199,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "ed837f81",
    "metadata": {},
    "outputs": [
     {
@@ -1376,7 +1330,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "551f9631",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1385,7 +1338,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "67b0853d",
    "metadata": {},
    "outputs": [
     {
@@ -1417,7 +1369,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "89d2f25b",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1440,7 +1391,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "af1f4f49",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1462,7 +1412,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f487c8d",
    "metadata": {},
    "source": [
     "##### BGP Peer Configuration"
@@ -1470,7 +1419,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00194fe3",
    "metadata": {},
    "source": [
     "Returns configuration settings for BGP peerings."
@@ -1478,7 +1426,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f77c2d96",
    "metadata": {},
    "source": [
     "Reports configuration settings for each configured BGP peering on each node in the network. This question reports peer-specific settings. Settings that are process-wide are reported by the bgpProcessConfiguration question."
@@ -1486,7 +1433,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a531a157",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1494,7 +1440,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "858595e5",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1505,7 +1450,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c5527cc",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1514,7 +1458,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "638fd4b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1523,7 +1466,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecbf6bd8",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1531,7 +1473,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c40fa042",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1557,7 +1498,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c110d354",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1566,7 +1506,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "b278a048",
    "metadata": {},
    "outputs": [
     {
@@ -1734,7 +1673,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f841ffb",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1743,7 +1681,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "eefd2078",
    "metadata": {},
    "outputs": [
     {
@@ -1781,7 +1718,6 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "c9a05c8e",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1804,7 +1740,6 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "6eef2887",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1826,7 +1761,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b976cf2",
    "metadata": {},
    "source": [
     "##### HSRP Properties"
@@ -1834,7 +1768,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b6f4fbd",
    "metadata": {},
    "source": [
     "Returns configuration settings of HSRP groups."
@@ -1842,7 +1775,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "523ca534",
    "metadata": {},
    "source": [
     "Lists information about HSRP groups on interfaces."
@@ -1850,7 +1782,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ee81c07",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1858,7 +1789,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c16a166",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1871,7 +1801,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6bf5b7fb",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1880,7 +1809,6 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "bf5400c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1889,7 +1817,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8aa6d487",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1897,7 +1824,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6af16684",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1913,7 +1839,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec5b467c",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1922,7 +1847,6 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "e575e577",
    "metadata": {},
    "outputs": [
     {
@@ -1997,7 +1921,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e13d497",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -2006,7 +1929,6 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "2b9cc870",
    "metadata": {},
    "outputs": [
     {
@@ -2034,7 +1956,6 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "08762504",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2057,7 +1978,6 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "09e5294e",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2079,7 +1999,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffcf52f2",
    "metadata": {},
    "source": [
     "##### OSPF Process Configuration"
@@ -2087,7 +2006,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3ba4b0f",
    "metadata": {},
    "source": [
     "Returns configuration parameters for OSPF routing processes."
@@ -2095,7 +2013,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5966f33",
    "metadata": {},
    "source": [
     "Returns the values of important properties for all OSPF processes running across the network."
@@ -2103,7 +2020,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54eacad3",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -2111,7 +2027,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd984006",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -2122,7 +2037,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bf1d8a5",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -2131,7 +2045,6 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "44af7834",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2140,7 +2053,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dfcddee",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -2148,7 +2060,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25a5203f",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -2165,7 +2076,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "164e1f7e",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -2174,7 +2084,6 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "7f1c76bb",
    "metadata": {},
    "outputs": [
     {
@@ -2288,7 +2197,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6e974be",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -2297,7 +2205,6 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "78c05284",
    "metadata": {},
    "outputs": [
     {
@@ -2326,7 +2233,6 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "9d4ebd7e",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2349,7 +2255,6 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "cc58dd9f",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2371,7 +2276,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93732ecd",
    "metadata": {},
    "source": [
     "##### OSPF Interface Configuration"
@@ -2379,7 +2283,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45dd22d7",
    "metadata": {},
    "source": [
     "Returns OSPF configuration of interfaces."
@@ -2387,7 +2290,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51488695",
    "metadata": {},
    "source": [
     "Returns the interface level OSPF configuration details for the interfaces in the network which run OSPF."
@@ -2395,7 +2297,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26277439",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -2403,7 +2304,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16381e7d",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -2414,7 +2314,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98d9c359",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -2423,7 +2322,6 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "62002ce2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2432,7 +2330,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37be94ed",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -2440,7 +2337,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7282874d",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -2459,7 +2355,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4be7e693",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -2468,7 +2363,6 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "ae3fcdd8",
    "metadata": {},
    "outputs": [
     {
@@ -2594,7 +2488,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53fa151e",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -2603,7 +2496,6 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "c1472b79",
    "metadata": {},
    "outputs": [
     {
@@ -2634,7 +2526,6 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "c0438091",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2657,7 +2548,6 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "5ce26b32",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2679,7 +2569,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5c94951",
    "metadata": {},
    "source": [
     "##### OSPF Area Configuration"
@@ -2687,7 +2576,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25a558ff",
    "metadata": {},
    "source": [
     "Returns configuration parameters of OSPF areas."
@@ -2695,7 +2583,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "450d55b7",
    "metadata": {},
    "source": [
     "Returns information about all OSPF areas defined across the network."
@@ -2703,7 +2590,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1df96113",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -2711,7 +2597,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "194b8da8",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -2721,7 +2606,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddd117af",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -2730,7 +2614,6 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "82b7c368",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2739,7 +2622,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "052f54a2",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -2747,7 +2629,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "132f6983",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -2763,7 +2644,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a173de89",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -2772,7 +2652,6 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "1793584f",
    "metadata": {},
    "outputs": [
     {
@@ -2880,7 +2759,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9955f1a3",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -2889,7 +2767,6 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "6abc53c4",
    "metadata": {},
    "outputs": [
     {
@@ -2917,7 +2794,6 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "d1a354d0",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2940,7 +2816,6 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "84a2e189",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -2962,7 +2837,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e43659dc",
    "metadata": {},
    "source": [
     "##### Multi-chassis LAG"
@@ -2970,7 +2844,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9f2e9ca",
    "metadata": {},
    "source": [
     "Returns MLAG configuration."
@@ -2978,7 +2851,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6552b90c",
    "metadata": {},
    "source": [
     "Lists the configuration settings for each MLAG domain in the network."
@@ -2986,7 +2858,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c1d0ca6",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -2994,7 +2865,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "153a8a27",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -3005,7 +2875,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48cf0781",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -3014,7 +2883,6 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "fcb07df0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3023,7 +2891,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05a55988",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -3031,7 +2898,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "110a35b3",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -3045,7 +2911,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc9f8eab",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -3054,7 +2919,6 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "c0864ff9",
    "metadata": {},
    "outputs": [
     {
@@ -3150,7 +3014,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da101c13",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -3159,7 +3022,6 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "0f64b6e2",
    "metadata": {},
    "outputs": [
     {
@@ -3185,7 +3047,6 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "d7991b8f",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -3208,7 +3069,6 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "4cbc17c4",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -3230,7 +3090,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1514c305",
    "metadata": {},
    "source": [
     "##### IP Owners"
@@ -3238,7 +3097,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfb4f027",
    "metadata": {},
    "source": [
     "Returns where IP addresses are attached in the network."
@@ -3246,7 +3104,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1f90c1c",
    "metadata": {},
    "source": [
     "For each device, lists the mapping from IPs to corresponding interface(s) and VRF(s)."
@@ -3254,7 +3111,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f2e3be8",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -3262,7 +3118,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dabfe5e9",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -3273,7 +3128,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6deef44a",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -3282,7 +3136,6 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "7794d3ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3291,7 +3144,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0225cbd2",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -3299,7 +3151,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8224468",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -3314,7 +3165,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "221d2d1d",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -3323,7 +3173,6 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "5fa7a46a",
    "metadata": {},
    "outputs": [
     {
@@ -3425,7 +3274,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29e2b26a",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -3434,7 +3282,6 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "09c47c18",
    "metadata": {},
    "outputs": [
     {
@@ -3461,7 +3308,6 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "c6158aae",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -3484,7 +3330,6 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "3d1e7b3d",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -3506,7 +3351,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7466dbd9",
    "metadata": {},
    "source": [
     "##### Named Structures"
@@ -3514,7 +3358,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21cf979b",
    "metadata": {},
    "source": [
     "Returns named structure definitions."
@@ -3522,7 +3365,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db1b9a36",
    "metadata": {},
    "source": [
     "Return structures defined in the configurations, represented in a vendor-independent JSON format."
@@ -3530,7 +3372,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c1cf818",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -3538,7 +3379,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d15bb50",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -3552,7 +3392,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc15e659",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -3561,7 +3400,6 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "4f815a33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3570,7 +3408,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1853da25",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -3578,7 +3415,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91cef5e3",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -3591,7 +3427,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0cd19bd",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -3600,7 +3435,6 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "dc8a673b",
    "metadata": {},
    "outputs": [
     {
@@ -3690,7 +3524,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc58edc7",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -3699,7 +3532,6 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "b6183e8d",
    "metadata": {},
    "outputs": [
     {
@@ -3724,7 +3556,6 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "6e51e1bd",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -3747,7 +3578,6 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "9ea62241",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -3769,7 +3599,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7481020f",
    "metadata": {},
    "source": [
     "##### Defined Structures"
@@ -3777,7 +3606,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "265b1833",
    "metadata": {},
    "source": [
     "Lists the structures defined in the network."
@@ -3785,7 +3613,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7331ef1c",
    "metadata": {},
    "source": [
     "Lists the structures defined in the network, along with the files and line numbers in which they are defined."
@@ -3793,7 +3620,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81f7c71c",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -3801,7 +3627,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a116707",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -3814,7 +3639,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d30c58e",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -3823,7 +3647,6 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "44091c03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3832,7 +3655,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "add5b82f",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -3840,7 +3662,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a576245",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -3852,7 +3673,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e23f725",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -3861,7 +3681,6 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "id": "6485ccff",
    "metadata": {},
    "outputs": [
     {
@@ -3945,7 +3764,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b056517",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -3954,7 +3772,6 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "id": "df1031de",
    "metadata": {},
    "outputs": [
     {
@@ -3978,7 +3795,6 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "id": "f6bb3d1b",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4001,7 +3817,6 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "a213301b",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4023,7 +3838,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f97a7853",
    "metadata": {},
    "source": [
     "##### Referenced Structures"
@@ -4031,7 +3845,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eef068c6",
    "metadata": {},
    "source": [
     "Lists the references in configuration files to vendor-specific structures."
@@ -4039,7 +3852,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4825592c",
    "metadata": {},
    "source": [
     "Lists the references in configuration files to vendor-specific structures, along with the line number, the name and the type of the structure referenced, and configuration context in which each reference occurs."
@@ -4047,7 +3859,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0db19d24",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -4055,7 +3866,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aae2ed7f",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -4067,7 +3877,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68a3345d",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -4076,7 +3885,6 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "c9fd5ec0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4085,7 +3893,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b35ac72",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -4093,7 +3900,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2382b573",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -4106,7 +3912,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "692e51ab",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -4115,7 +3920,6 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "id": "392c0f2f",
    "metadata": {},
    "outputs": [
     {
@@ -4205,7 +4009,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4938ef53",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -4214,7 +4017,6 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "b93f3598",
    "metadata": {},
    "outputs": [
     {
@@ -4239,7 +4041,6 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "dfc5bd42",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4262,7 +4063,6 @@
   {
    "cell_type": "code",
    "execution_count": 69,
-   "id": "25b4121a",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4284,7 +4084,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e89697e1",
    "metadata": {},
    "source": [
     "##### Undefined References"
@@ -4292,7 +4091,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b59fdf0c",
    "metadata": {},
    "source": [
     "Identifies undefined references in configuration."
@@ -4300,7 +4098,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4a858dd",
    "metadata": {},
    "source": [
     "Finds configurations that have references to named structures (e.g., ACLs) that are not defined. Such occurrences indicate errors and can have serious consequences in some cases."
@@ -4308,7 +4105,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "603aa209",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -4316,7 +4112,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "518f385b",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -4326,7 +4121,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "476ee99b",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -4335,7 +4129,6 @@
   {
    "cell_type": "code",
    "execution_count": 70,
-   "id": "8958fe7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4344,7 +4137,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc275bde",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -4352,7 +4144,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4b2d175",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -4366,7 +4157,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcc41d27",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -4375,7 +4165,6 @@
   {
    "cell_type": "code",
    "execution_count": 71,
-   "id": "d197278d",
    "metadata": {},
    "outputs": [
     {
@@ -4435,7 +4224,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc7df48e",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -4444,7 +4232,6 @@
   {
    "cell_type": "code",
    "execution_count": 72,
-   "id": "c8607715",
    "metadata": {},
    "outputs": [
     {
@@ -4470,7 +4257,6 @@
   {
    "cell_type": "code",
    "execution_count": 73,
-   "id": "7d960e1b",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4493,7 +4279,6 @@
   {
    "cell_type": "code",
    "execution_count": 74,
-   "id": "4e56bff0",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4515,7 +4300,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bdf4ab94",
    "metadata": {},
    "source": [
     "##### Unused Structures"
@@ -4523,7 +4307,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d0c1d50",
    "metadata": {},
    "source": [
     "Returns nodes with structures such as ACLs, routemaps, etc. that are defined but not used."
@@ -4531,7 +4314,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c278b8a",
    "metadata": {},
    "source": [
     "Return nodes with structures such as ACLs, routes, etc. that are defined but not used. This may represent a bug in the configuration, which may have occurred because a final step in a template or MOP was not completed. Or it could be harmless extra configuration generated from a master template that is not meant to be used on those nodes."
@@ -4539,7 +4321,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7806fa92",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -4547,7 +4328,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e0a11b1",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -4557,7 +4337,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "651dc6a7",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -4566,7 +4345,6 @@
   {
    "cell_type": "code",
    "execution_count": 75,
-   "id": "a59a566f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4575,7 +4353,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "969d46d6",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -4583,7 +4360,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e83bf198",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -4595,7 +4371,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec26b52b",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -4604,7 +4379,6 @@
   {
    "cell_type": "code",
    "execution_count": 76,
-   "id": "f21302bb",
    "metadata": {},
    "outputs": [
     {
@@ -4688,7 +4462,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c842900",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -4697,7 +4470,6 @@
   {
    "cell_type": "code",
    "execution_count": 77,
-   "id": "58be267e",
    "metadata": {},
    "outputs": [
     {
@@ -4721,7 +4493,6 @@
   {
    "cell_type": "code",
    "execution_count": 78,
-   "id": "cccf8d02",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4744,7 +4515,6 @@
   {
    "cell_type": "code",
    "execution_count": 79,
-   "id": "204d82e2",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -4766,7 +4536,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2a93af9",
    "metadata": {},
    "source": [
     "##### VLAN Properties"
@@ -4774,7 +4543,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fc197ff",
    "metadata": {},
    "source": [
     "Returns configuration settings of switched VLANs."
@@ -4782,7 +4550,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d11fd95",
    "metadata": {},
    "source": [
     "Lists information about implicitly and explicitly configured switched VLANs."
@@ -4790,7 +4557,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91cab316",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -4798,7 +4564,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4877eaf",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -4811,7 +4576,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c511202b",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -4820,7 +4584,6 @@
   {
    "cell_type": "code",
    "execution_count": 80,
-   "id": "8606cd7a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4829,7 +4592,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42608585",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -4837,7 +4599,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88178e67",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -4850,7 +4611,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a62fb6d7",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -4859,7 +4619,6 @@
   {
    "cell_type": "code",
    "execution_count": 81,
-   "id": "bc12cfba",
    "metadata": {},
    "outputs": [
     {
@@ -4949,7 +4708,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba7b8c1a",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -4958,7 +4716,6 @@
   {
    "cell_type": "code",
    "execution_count": 82,
-   "id": "0eacd8f3",
    "metadata": {},
    "outputs": [
     {
@@ -4983,7 +4740,6 @@
   {
    "cell_type": "code",
    "execution_count": 83,
-   "id": "8b5d4bec",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -5006,7 +4762,6 @@
   {
    "cell_type": "code",
    "execution_count": 84,
-   "id": "7fdaf213",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -5028,7 +4783,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0adc25a7",
    "metadata": {},
    "source": [
     "##### VRRP Properties"
@@ -5036,7 +4790,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78c5e903",
    "metadata": {},
    "source": [
     "Returns configuration settings of VRRP groups."
@@ -5044,7 +4797,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "216e7f78",
    "metadata": {},
    "source": [
     "Lists information about VRRP groups on interfaces."
@@ -5052,7 +4804,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fab0700",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -5060,7 +4811,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "686bf763",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -5073,7 +4823,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6f6491c",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -5082,7 +4831,6 @@
   {
    "cell_type": "code",
    "execution_count": 85,
-   "id": "5eaba245",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5091,7 +4839,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a31fdd81",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -5099,7 +4846,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2578967",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -5115,7 +4861,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7465a90",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -5124,7 +4869,6 @@
   {
    "cell_type": "code",
    "execution_count": 86,
-   "id": "5f94cd3a",
    "metadata": {},
    "outputs": [
     {
@@ -5199,7 +4943,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad1e9154",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -5208,7 +4951,6 @@
   {
    "cell_type": "code",
    "execution_count": 87,
-   "id": "430bef38",
    "metadata": {},
    "outputs": [
     {
@@ -5236,7 +4978,6 @@
   {
    "cell_type": "code",
    "execution_count": 88,
-   "id": "ccce35c6",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -5259,7 +5000,6 @@
   {
    "cell_type": "code",
    "execution_count": 89,
-   "id": "7ac9b00d",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -5281,7 +5021,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a63e5bd",
    "metadata": {},
    "source": [
     "##### A10 Virtual Server Configuration"
@@ -5289,7 +5028,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6da33835",
    "metadata": {},
    "source": [
     "Returns Virtual Server configuration of A10 devices."
@@ -5297,7 +5035,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7000484c",
    "metadata": {},
    "source": [
     "Lists all the virtual-server to service-group to server mappings in A10 configurations."
@@ -5305,7 +5042,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102046bd",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -5313,7 +5049,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4464f3c7",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -5324,7 +5059,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfa5542a",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -5333,7 +5067,6 @@
   {
    "cell_type": "code",
    "execution_count": 90,
-   "id": "6bd41de4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5342,7 +5075,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8782c1e8",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -5350,7 +5082,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67968cdd",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -5371,7 +5102,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0a71ea1",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -5380,7 +5110,6 @@
   {
    "cell_type": "code",
    "execution_count": 91,
-   "id": "3fb393c3",
    "metadata": {},
    "outputs": [
     {
@@ -5457,7 +5186,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cb23040",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -5466,7 +5194,6 @@
   {
    "cell_type": "code",
    "execution_count": 92,
-   "id": "4db4fe2c",
    "metadata": {},
    "outputs": [
     {
@@ -5499,7 +5226,6 @@
   {
    "cell_type": "code",
    "execution_count": 93,
-   "id": "4bf35836",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -5522,7 +5248,6 @@
   {
    "cell_type": "code",
    "execution_count": 94,
-   "id": "b639c482",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -5544,7 +5269,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cac2be40",
    "metadata": {},
    "source": [
     "##### F5 BIG-IP VIP Configuration"
@@ -5552,7 +5276,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecffb19f",
    "metadata": {},
    "source": [
     "Returns VIP configuration of F5 BIG-IP devices."
@@ -5560,7 +5283,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6027c33e",
    "metadata": {},
    "source": [
     "Lists all the VIP to server IP mappings contained in F5 BIP-IP configurations."
@@ -5568,7 +5290,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3ef0940",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -5576,7 +5297,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21322a2e",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -5586,7 +5306,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91f029d6",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -5595,7 +5314,6 @@
   {
    "cell_type": "code",
    "execution_count": 95,
-   "id": "a16232f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5604,7 +5322,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "436a5545",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -5612,7 +5329,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bccab8eb",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -5626,7 +5342,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0076f1e5",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -5635,7 +5350,6 @@
   {
    "cell_type": "code",
    "execution_count": 96,
-   "id": "9489c454",
    "metadata": {},
    "outputs": [
     {
@@ -5713,7 +5427,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d625d448",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -5722,7 +5435,6 @@
   {
    "cell_type": "code",
    "execution_count": 97,
-   "id": "a2b65147",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/notebooks/filters.ipynb
+++ b/docs/source/notebooks/filters.ipynb
@@ -36,7 +36,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "517b159e",
    "metadata": {},
    "source": [
     "#### Access-lists and firewall rules"
@@ -44,7 +43,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26a7e2f9",
    "metadata": {},
    "source": [
     "This category of questions allows you to analyze the behavior of access\n",
@@ -54,7 +52,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff72b1ad",
    "metadata": {},
    "source": [
     "* [Filter Line Reachability](#Filter-Line-Reachability)\n",
@@ -67,7 +64,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a373d1f3",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -90,7 +86,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "27422520",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -112,7 +107,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "022c0618",
    "metadata": {},
    "source": [
     "##### Filter Line Reachability"
@@ -120,7 +114,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2a32a76",
    "metadata": {},
    "source": [
     "Returns unreachable lines in filters (ACLs and firewall rules)."
@@ -128,7 +121,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12e2dd5e",
    "metadata": {},
    "source": [
     "Finds all lines in the specified filters that will not match any packet, either because of being shadowed by prior lines or because of its match condition being empty."
@@ -136,7 +128,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d2daece",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -144,7 +135,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "402ac86e",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -156,7 +146,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccc89365",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -165,7 +154,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "71910654",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +162,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "256dd0ae",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -182,7 +169,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8da3fc65",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -198,7 +184,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d76cee48",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -207,7 +192,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "89e90d3b",
    "metadata": {},
    "outputs": [
     {
@@ -282,7 +266,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da81df67",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -291,7 +274,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c1df015a",
    "metadata": {},
    "outputs": [
     {
@@ -319,7 +301,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1b658a74",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -342,7 +323,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e1ae54b6",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -364,7 +344,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34a33d6c",
    "metadata": {},
    "source": [
     "##### Search Filters"
@@ -372,7 +351,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f78e5067",
    "metadata": {},
    "source": [
     "Finds flows for which a filter takes a particular behavior."
@@ -380,7 +358,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ac89c4e",
    "metadata": {},
    "source": [
     "This question searches for flows for which a filter (access control list) has a particular behavior. The behaviors can be: that the filter permits the flow (`permit`), that it denies the flow (`deny`), or that the flow is matched by a particular line (`matchLine <lineNumber>`). Filters are selected using node and filter specifiers, which might match multiple filters. In this case, a (possibly different) flow will be found for each filter."
@@ -388,7 +365,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49ea3c3a",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -396,7 +372,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae1bb563",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -411,7 +386,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64ebca91",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -420,7 +394,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "2024ac26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +402,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c370d56",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -437,7 +409,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abc90a16",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -452,7 +423,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce96bb32",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -461,7 +431,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "65967333",
    "metadata": {},
    "outputs": [
     {
@@ -523,7 +492,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66cd7a5e",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -532,7 +500,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "99a479ea",
    "metadata": {},
    "outputs": [
     {
@@ -559,7 +526,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9886757c",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -582,7 +548,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "998fe73c",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -604,7 +569,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07e85a32",
    "metadata": {},
    "source": [
     "##### Test Filters"
@@ -612,7 +576,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d73eb7d",
    "metadata": {},
    "source": [
     "Returns how a flow is processed by a filter (ACLs, firewall rules)."
@@ -620,7 +583,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5510cde1",
    "metadata": {},
    "source": [
     "Shows how the specified flow is processed through the specified filters, returning its permit/deny status as well as the line(s) it matched."
@@ -628,7 +590,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "501a8778",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -636,7 +597,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e554831",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -649,7 +609,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad7270d2",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -658,7 +617,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "601ddf3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +625,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "272c3721",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -675,7 +632,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2021ae8",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -690,7 +646,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66694003",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -699,7 +654,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "47883371",
    "metadata": {},
    "outputs": [
     {
@@ -761,7 +715,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47ede178",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -770,7 +723,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "e11e4488",
    "metadata": {},
    "outputs": [
     {
@@ -797,7 +749,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "d1419ff7",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -820,7 +771,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "6e4dbb2d",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -842,7 +792,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f801a277",
    "metadata": {},
    "source": [
     "##### Find Matching Filter Lines"
@@ -850,7 +799,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "910ca73f",
    "metadata": {},
    "source": [
     "Returns lines in filters (ACLs and firewall rules) that match any packet within the specified header constraints."
@@ -858,7 +806,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97cde04c",
    "metadata": {},
    "source": [
     "Finds all lines in the specified filters that match any packet within the specified header constraints."
@@ -866,7 +813,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "351ef3e3",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -874,7 +820,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a6f9d5b",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -888,7 +833,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80837dea",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -897,7 +841,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "f2cb5c2a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -906,7 +849,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5f4448d",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -914,7 +856,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33d50463",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -928,7 +869,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f79779b3",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -937,7 +877,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "249dac2d",
    "metadata": {},
    "outputs": [
     {
@@ -1033,7 +972,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a1055b1",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1042,7 +980,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "ae497da9",
    "metadata": {},
    "outputs": [
     {
@@ -1068,7 +1005,6 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "8e8452dd",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1091,7 +1027,6 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "ed4f6eff",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1113,7 +1048,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f957c483",
    "metadata": {},
    "source": [
     "##### Check SNMP Community Clients"
@@ -1121,7 +1055,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e169df35",
    "metadata": {},
    "source": [
     "Checks if an SNMP community permits specified client IPs."
@@ -1129,7 +1062,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "187ce031",
    "metadata": {},
    "source": [
     "This question checks if the specified SNMP community permits the specified client IPs on specified devices. It reports if any device does not have the community or the set of permitted client IPs by the community does not match those specified in the question. If the community exists and permits exactly the specified client IPs, the device is not included in the output. The question currently only supports Arista, Cisco-NXOS, and Juniper devices. For all others, it will report an UNSUPPORTED_DEVICE status in the output."
@@ -1137,7 +1069,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be0c3fd8",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1145,7 +1076,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "871d3b55",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1157,7 +1087,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8daa381",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1166,7 +1095,6 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "521974ad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1175,7 +1103,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b92d0780",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1183,7 +1110,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2b3ce4f",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1195,7 +1121,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3c39c6f",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1204,7 +1129,6 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "c826256d",
    "metadata": {},
    "outputs": [
     {
@@ -1267,7 +1191,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23146432",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1276,7 +1199,6 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "54d0f69e",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/notebooks/resolvingSpecifiers.ipynb
+++ b/docs/source/notebooks/resolvingSpecifiers.ipynb
@@ -36,7 +36,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "150b238a",
    "metadata": {},
    "source": [
     "#### Resolving Specifiers"
@@ -44,7 +43,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12e8ab65",
    "metadata": {},
    "source": [
     "Specifier grammars allow you to specify complex inputs for Batfish questions.\n",
@@ -54,7 +52,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9399a80b",
    "metadata": {},
    "source": [
     "* [Resolve Location Specifier](#Resolve-Location-Specifier)\n",
@@ -68,7 +65,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f3295cd7",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -91,7 +87,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "02c54c9c",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -113,7 +108,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f4c601b",
    "metadata": {},
    "source": [
     "##### Resolve Location Specifier"
@@ -121,7 +115,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5b4b8fa",
    "metadata": {},
    "source": [
     "Returns the set of locations corresponding to a locationSpec value."
@@ -129,7 +122,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d29e851e",
    "metadata": {},
    "source": [
     "Helper question that shows how specified locationSpec values resolve to the locations in the network."
@@ -137,7 +129,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6bb8e63",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -145,7 +136,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4dabd29f",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -156,7 +146,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1facd9d",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -165,7 +154,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "aad8dcb3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +162,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10bc5255",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -182,7 +169,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b97f0fe8",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -192,7 +178,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3aabdb50",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -201,7 +186,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8d5ba5ea",
    "metadata": {},
    "outputs": [
     {
@@ -253,7 +237,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ac1ebdc",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -262,7 +245,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "45f02827",
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +266,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1fd6a704",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -307,7 +288,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "caa3d350",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -329,7 +309,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b3dfae7",
    "metadata": {},
    "source": [
     "##### Resolve Filter Specifier"
@@ -337,7 +316,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c255dd6",
    "metadata": {},
    "source": [
     "Returns the set of filters corresponding to a filterSpec value."
@@ -345,7 +323,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "821222e4",
    "metadata": {},
    "source": [
     "Helper question that shows how specified filterSpec values resolve to the filters in the network."
@@ -353,7 +330,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b1a608e",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -361,7 +337,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "803449da",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -373,7 +348,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "633baca3",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -382,7 +356,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "d604216e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +364,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "315d6560",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -399,7 +371,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "644e0a90",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -410,7 +381,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90973858",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -419,7 +389,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "6ffec489",
    "metadata": {},
    "outputs": [
     {
@@ -473,7 +442,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57a2979b",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -482,7 +450,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "795cdbea",
    "metadata": {},
    "outputs": [
     {
@@ -505,7 +472,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "d9a1f2c4",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -528,7 +494,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "fd472cb1",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -550,7 +515,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9792284",
    "metadata": {},
    "source": [
     "##### Resolve Node Specifier"
@@ -558,7 +522,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99a34bcc",
    "metadata": {},
    "source": [
     "Returns the set of nodes corresponding to a nodeSpec value."
@@ -566,7 +529,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daac5fca",
    "metadata": {},
    "source": [
     "Helper question that shows how specified nodeSpec values resolve to the nodes in the network."
@@ -574,7 +536,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ed3846f",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -582,7 +543,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a74a4b6d",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -593,7 +553,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "faf56ec6",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -602,7 +561,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9da7462b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +569,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d7686f2",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -619,7 +576,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36bf870d",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -629,7 +585,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9afc28d",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -638,7 +593,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "fa25d172",
    "metadata": {},
    "outputs": [
     {
@@ -710,7 +664,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef4bfd0d",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -719,7 +672,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "aaf6c9df",
    "metadata": {},
    "outputs": [
     {
@@ -741,7 +693,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "bed27d21",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -764,7 +715,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "1a6cdc4f",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -786,7 +736,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77f3e17d",
    "metadata": {},
    "source": [
     "##### Resolve Interface Specifier"
@@ -794,7 +743,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80bd14c7",
    "metadata": {},
    "source": [
     "Returns the set of interfaces corresponding to an interfaceSpec value."
@@ -802,7 +750,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c67dfaf6",
    "metadata": {},
    "source": [
     "Helper question that shows how specified interfaceSpec values resolve to the interfaces in the network."
@@ -810,7 +757,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b4248e5",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -818,7 +764,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa5b07a2",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -830,7 +775,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2d4e222",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -839,7 +783,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "d4cd0260",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,7 +791,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfe6e6e6",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -856,7 +798,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ba6ffa3",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -866,7 +807,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45a71e1e",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -875,7 +815,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "9154131e",
    "metadata": {},
    "outputs": [
     {
@@ -947,7 +886,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a27447d",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -956,7 +894,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "4c891961",
    "metadata": {},
    "outputs": [
     {
@@ -978,7 +915,6 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "648049e3",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1001,7 +937,6 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "6d9d130c",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1023,7 +958,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7f5f1c8",
    "metadata": {},
    "source": [
     "##### Resolve IPs from Location Specifier"
@@ -1031,7 +965,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42143962",
    "metadata": {},
    "source": [
     "Returns IPs that are auto-assigned to locations."
@@ -1039,7 +972,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "180fff1b",
    "metadata": {},
    "source": [
     "Helper question that shows IPs that will be assigned to specified locationSpec values by questions are automatically pick IPs based on locations."
@@ -1047,7 +979,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4f8eed0",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1055,7 +986,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d1fefc3",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1066,7 +996,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54de41f7",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1075,7 +1004,6 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "81fc4a05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1012,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89662471",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1092,7 +1019,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e389bf52",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1103,7 +1029,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "832d839d",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1112,7 +1037,6 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "8dc7b2d4",
    "metadata": {},
    "outputs": [
     {
@@ -1169,7 +1093,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "568cd187",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1178,7 +1101,6 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "d6c0d3e0",
    "metadata": {},
    "outputs": [
     {
@@ -1201,7 +1123,6 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "ba0df672",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1224,7 +1145,6 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "8f32a9ad",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1246,7 +1166,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc6aa792",
    "metadata": {},
    "source": [
     "##### Resolve IP Specifier"
@@ -1254,7 +1173,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a6c370b",
    "metadata": {},
    "source": [
     "Returns the IP address space corresponding to an ipSpec value."
@@ -1262,7 +1180,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20a4447c",
    "metadata": {},
    "source": [
     "Helper question that shows how specified ipSpec values resolve to IPs."
@@ -1270,7 +1187,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e66ae598",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1278,7 +1194,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19015700",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1289,7 +1204,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "604ce9e0",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1298,7 +1212,6 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "37d20d1e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1307,7 +1220,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "559d0244",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1315,7 +1227,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d9fe877",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1325,7 +1236,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64a26393",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1334,7 +1244,6 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "58d7d0e8",
    "metadata": {},
    "outputs": [
     {
@@ -1386,7 +1295,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fbd4623",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1395,7 +1303,6 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "365ca46b",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/notebooks/routingProtocols.ipynb
+++ b/docs/source/notebooks/routingProtocols.ipynb
@@ -36,7 +36,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d70fb622",
    "metadata": {},
    "source": [
     "#### Routing Protocol Sessions and Policies"
@@ -44,7 +43,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93f3fc35",
    "metadata": {},
    "source": [
     "This category of questions reveals information regarding which routing\n",
@@ -54,7 +52,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf6a3894",
    "metadata": {},
    "source": [
     "* [BGP Session Compatibility](#BGP-Session-Compatibility)\n",
@@ -69,7 +66,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "65659da2",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -92,7 +88,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "09ebcb59",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -114,7 +109,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de9aa8e2",
    "metadata": {},
    "source": [
     "##### BGP Session Compatibility"
@@ -122,7 +116,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af611338",
    "metadata": {},
    "source": [
     "Returns the compatibility of configured BGP sessions."
@@ -130,7 +123,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e3d9770",
    "metadata": {},
    "source": [
     "Checks the settings of each configured BGP peering and reports any issue with those settings locally or incompatiblity with its remote counterparts. Each row represents one configured BGP peering on a node and contains information about the session it is meant to establish. For dynamic peers, there is one row per compatible remote peer. Statuses that indicate an independently misconfigured peerings include NO_LOCAL_AS, NO_REMOTE_AS, NO_LOCAL_IP (for eBGP single-hop peerings), LOCAL_IP_UNKNOWN_STATICALLY (for iBGP or eBGP multi-hop peerings), NO_REMOTE_IP (for point-to-point peerings), and NO_REMOTE_PREFIX (for dynamic peerings). INVALID_LOCAL_IP indicates that the peering's configured local IP does not belong to any active interface on the node; UNKNOWN_REMOTE indicates that the configured remote IP is not present in the network. A locally valid point-to-point peering is deemed HALF_OPEN if it has no compatible remote peers, UNIQUE_MATCH if it has exactly one compatible remote peer, or MULTIPLE_REMOTES if it has multiple compatible remote peers. A locally valid dynamic peering is deemed NO_MATCH_FOUND if it has no compatible remote peers, or DYNAMIC_MATCH if it has at least one compatible remote peer."
@@ -138,7 +130,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d329f833",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -146,7 +137,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f204407",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -159,7 +149,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21db1f67",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -168,7 +157,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "5e3179fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +165,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69266ba9",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -185,7 +172,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58dee9f5",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -207,7 +193,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e973a64d",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -216,7 +201,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "1bedf987",
    "metadata": {},
    "outputs": [
     {
@@ -360,7 +344,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7af8089",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -369,7 +352,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "af0c40a7",
    "metadata": {},
    "outputs": [
     {
@@ -403,7 +385,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "fba65502",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -426,7 +407,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b5597831",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -448,7 +428,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8263f831",
    "metadata": {},
    "source": [
     "##### BGP Session Status"
@@ -456,7 +435,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcd33c35",
    "metadata": {},
    "source": [
     "Returns the dynamic status of configured BGP sessions."
@@ -464,7 +442,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5f47e31",
    "metadata": {},
    "source": [
     "Checks whether configured BGP peerings can be established. Each row represents one configured BGP peering and contains information about the session it is configured to establish. For dynamic peerings, one row is shown per compatible remote peer. Possible statuses for each session are NOT_COMPATIBLE, ESTABLISHED, and NOT_ESTABLISHED. NOT_COMPATIBLE sessions are those where one or both peers are misconfigured; the BgpSessionCompatibility question provides further insight into the nature of the configuration error. NOT_ESTABLISHED sessions are those that are configured compatibly but will not come up because peers cannot reach each other (e.g., due to being blocked by an ACL). ESTABLISHED sessions are those that are compatible and are expected to come up."
@@ -472,7 +449,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f0a1b87",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -480,7 +456,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cf7b7a3",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -493,7 +468,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02a8d202",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -502,7 +476,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "12a12aaa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +484,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cedb7341",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -519,7 +491,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d6de2f5",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -541,7 +512,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3e72fe2",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -550,7 +520,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "e1841ae3",
    "metadata": {},
    "outputs": [
     {
@@ -694,7 +663,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f89d4bdf",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -703,7 +671,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "623e699d",
    "metadata": {},
    "outputs": [
     {
@@ -737,7 +704,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "97389251",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -760,7 +726,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "9c99cd04",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -782,7 +747,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93c5c3f6",
    "metadata": {},
    "source": [
     "##### BGP Edges"
@@ -790,7 +754,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f813b06",
    "metadata": {},
    "source": [
     "Returns BGP adjacencies."
@@ -798,7 +761,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bfdbaec",
    "metadata": {},
    "source": [
     "Lists all BGP adjacencies in the network."
@@ -806,7 +768,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0142ae83",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -814,7 +775,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3408977c",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -825,7 +785,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6e2882f",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -834,7 +793,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9aded60a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -843,7 +801,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f15d2674",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -851,7 +808,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4aa2189",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -868,7 +824,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cc87db0",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -877,7 +832,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "d5fa4032",
    "metadata": {},
    "outputs": [
     {
@@ -991,7 +945,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68655e0f",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1000,7 +953,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "62abb314",
    "metadata": {},
    "outputs": [
     {
@@ -1029,7 +981,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "824b3744",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1052,7 +1003,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "794a8b69",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1074,7 +1024,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76dbdd37",
    "metadata": {},
    "source": [
     "##### OSPF Session Compatibility"
@@ -1082,7 +1031,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8af2880",
    "metadata": {},
    "source": [
     "Returns compatible OSPF sessions."
@@ -1090,7 +1038,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61b15065",
    "metadata": {},
    "source": [
     "Returns compatible OSPF sessions in the network. A session is compatible if the interfaces involved are not shutdown and do run OSPF, are not OSPF passive and are associated with the same OSPF area."
@@ -1098,7 +1045,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7e4cab0",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1106,7 +1052,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4282e4bd",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1118,7 +1063,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e700ef9a",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1127,7 +1071,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "a6bd98ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1136,7 +1079,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30feca2a",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1144,7 +1086,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d6375fa",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1162,7 +1103,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebff518a",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1171,7 +1111,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "3ab7a128",
    "metadata": {},
    "outputs": [
     {
@@ -1291,7 +1230,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "369a873c",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1300,7 +1238,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "14e516d0",
    "metadata": {},
    "outputs": [
     {
@@ -1330,7 +1267,6 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "247c0b38",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1353,7 +1289,6 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "cb6007a0",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1375,7 +1310,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80435e4f",
    "metadata": {},
    "source": [
     "##### OSPF Edges"
@@ -1383,7 +1317,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61f6985f",
    "metadata": {},
    "source": [
     "Returns OSPF adjacencies."
@@ -1391,7 +1324,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b945da3",
    "metadata": {},
    "source": [
     "Lists all OSPF adjacencies in the network."
@@ -1399,7 +1331,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e05b3f9",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1407,7 +1338,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28c741d6",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1418,7 +1348,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c57f60c",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1427,7 +1356,6 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "05ba19b8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1436,7 +1364,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be6f886b",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1444,7 +1371,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39aeb334",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1455,7 +1381,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17acca5d",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1464,7 +1389,6 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "384c1364",
    "metadata": {},
    "outputs": [
     {
@@ -1542,7 +1466,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9823d32b",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1551,7 +1474,6 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "37e6e251",
    "metadata": {},
    "outputs": [
     {
@@ -1574,7 +1496,6 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "bc47549b",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1597,7 +1518,6 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "e3645462",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1619,7 +1539,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "871327d0",
    "metadata": {},
    "source": [
     "##### Test Route Policies"
@@ -1627,7 +1546,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16a84316",
    "metadata": {},
    "source": [
     "Evaluates the processing of a route by a given policy."
@@ -1635,7 +1553,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad5be83c",
    "metadata": {},
    "source": [
     "Find how the specified route is processed through the specified routing policies."
@@ -1643,7 +1560,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32fecedf",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1651,7 +1567,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0002ff9",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1665,7 +1580,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9da2270c",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1674,7 +1588,6 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "e3e9fdf8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1683,7 +1596,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b78c928",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1691,7 +1603,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "896b3fbc",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1707,7 +1618,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "724d4264",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1716,7 +1626,6 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "e9186f53",
    "metadata": {},
    "outputs": [
     {
@@ -1852,7 +1761,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7e0c0f5",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1861,7 +1769,6 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "cf8b6d68",
    "metadata": {},
    "outputs": [
     {
@@ -1889,7 +1796,6 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "c59e8e01",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1912,7 +1818,6 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "bec9f2b9",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1934,7 +1839,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3814fc8",
    "metadata": {},
    "source": [
     "##### Search Route Policies"
@@ -1942,7 +1846,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b59f837",
    "metadata": {},
    "source": [
     "Finds route announcements for which a route policy has a particular behavior."
@@ -1950,7 +1853,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dd9b09a",
    "metadata": {},
    "source": [
     "This question finds route announcements for which a route policy has a particular behavior. The behaviors can be: that the policy permits the route (`permit`) or that it denies the route (`deny`). Constraints can be imposed on the input route announcements of interest and, in the case of a `permit` action, also on the output route announcements of interest. Route policies are selected using node and policy specifiers, which might match multiple policies. In this case, a (possibly different) answer will be found for each policy. _Note:_ This question currently does not support all of the route policy features that Batfish supports. The question only supports common forms of matching on prefixes, communities, and AS-paths, as well as common forms of setting communities, the local preference, and the metric. The question logs all unsupported features that it encounters as warnings. Due to unsupported features, it is possible for the question to return no answers even for route policies that can in fact exhibit the specified behavior."
@@ -1958,7 +1860,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2edc664b",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1966,7 +1867,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c93ac1d",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1982,7 +1882,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d97849b",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1991,7 +1890,6 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "8af190b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2000,7 +1898,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e181e85a",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -2008,7 +1905,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2069027",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -2024,7 +1920,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b515729",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -2033,7 +1928,6 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "062af3bb",
    "metadata": {},
    "outputs": [
     {
@@ -2103,7 +1997,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "941cc481",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -2112,7 +2005,6 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "37d8ad4d",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/notebooks/routingTables.ipynb
+++ b/docs/source/notebooks/routingTables.ipynb
@@ -36,7 +36,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bcc356a5",
    "metadata": {},
    "source": [
     "#### Routing and Forwarding Tables"
@@ -44,7 +43,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce547ed3",
    "metadata": {},
    "source": [
     "This category of questions allows you to query the RIBs and FIBs computed\n",
@@ -53,7 +51,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7be29277",
    "metadata": {},
    "source": [
     "* [Routes](#Routes)\n",
@@ -65,7 +62,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5fd8572b",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -88,7 +84,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "aee4c56c",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -110,7 +105,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4b19f3e",
    "metadata": {},
    "source": [
     "##### Routes"
@@ -118,7 +112,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5de29ac1",
    "metadata": {},
    "source": [
     "Returns routing tables."
@@ -126,7 +119,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7cf9235b",
    "metadata": {},
    "source": [
     "Shows routes for specified RIB, VRF, and node(s)."
@@ -134,7 +126,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20fc470c",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -142,7 +133,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffddb3c6",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -157,7 +147,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "299b2967",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -166,7 +155,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "011b884d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +163,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7413b3ba",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -183,7 +170,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63b87986",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -202,7 +188,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c07894ce",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -211,7 +196,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "7b29d69c",
    "metadata": {},
    "outputs": [
     {
@@ -337,7 +321,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22d5b0d4",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -346,7 +329,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "99bd784f",
    "metadata": {},
    "outputs": [
     {
@@ -377,7 +359,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d2e30c49",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -400,7 +381,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "4b04474d",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -422,7 +402,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1785fa54",
    "metadata": {},
    "source": [
     "##### BGP RIB"
@@ -430,7 +409,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "716912fd",
    "metadata": {},
    "source": [
     "Returns routes in the BGP RIB."
@@ -438,7 +416,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "344836f7",
    "metadata": {},
    "source": [
     "Shows BGP routes for specified VRF and node(s). This question is not available in Batfish containers on dockerhub prior to March 29, 2021."
@@ -446,7 +423,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcda6fc2",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -454,7 +430,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4e8d5e4",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -468,7 +443,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e73fc141",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -477,7 +451,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "2d189603",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +459,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ffbfbe9",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -494,7 +466,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea38b572",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -524,7 +495,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bf6c3fc",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -533,7 +503,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "37f733ad",
    "metadata": {},
    "outputs": [
     {
@@ -725,7 +694,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58a68b6d",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -734,7 +702,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "75037654",
    "metadata": {},
    "outputs": [
     {
@@ -776,7 +743,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "cc5b335d",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -799,7 +765,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "3c3002fa",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -821,7 +786,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "842dbe90",
    "metadata": {},
    "source": [
     "##### EVPN RIB"
@@ -829,7 +793,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "526eb0cd",
    "metadata": {},
    "source": [
     "Returns routes in the EVPN RIB."
@@ -837,7 +800,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63a37145",
    "metadata": {},
    "source": [
     "Shows EVPN routes for specified VRF and node(s). This question is not available in Batfish containers on dockerhub prior to March 29, 2021."
@@ -845,7 +807,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27aee7d6",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -853,7 +814,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd22140",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -866,7 +826,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d6c5af4",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -875,7 +834,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "277e27d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -884,7 +842,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3c06e30",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -892,7 +849,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3917efee",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -922,7 +878,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfc4530e",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -931,7 +886,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "c10c66b0",
    "metadata": {},
    "outputs": [
     {
@@ -1130,7 +1084,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a1286f3",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1139,7 +1092,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "7a6e0ef0",
    "metadata": {},
    "outputs": [
     {
@@ -1181,7 +1133,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "cfa63fc6",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1204,7 +1155,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "5c5372f1",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -1226,7 +1176,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e1e5678",
    "metadata": {},
    "source": [
     "##### Longest Prefix Match"
@@ -1234,7 +1183,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f40cf2b1",
    "metadata": {},
    "source": [
     "Returns routes that are longest prefix match for a given IP address."
@@ -1242,7 +1190,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44e66048",
    "metadata": {},
    "source": [
     "Return longest prefix match routes for a given IP in the RIBs of specified nodes and VRFs."
@@ -1250,7 +1197,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed864d38",
    "metadata": {},
    "source": [
     "###### **Inputs**"
@@ -1258,7 +1204,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16221f87",
    "metadata": {},
    "source": [
     "Name | Description | Type | Optional | Default Value\n",
@@ -1270,7 +1215,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "887acf91",
    "metadata": {},
    "source": [
     "###### **Invocation**"
@@ -1279,7 +1223,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "149e5f02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1288,7 +1231,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "092d9b95",
    "metadata": {},
    "source": [
     "###### **Return Value**"
@@ -1296,7 +1238,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4c8a6b5",
    "metadata": {},
    "source": [
     "Name | Description | Type\n",
@@ -1310,7 +1251,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a0ed974",
    "metadata": {},
    "source": [
     "Print the first 5 rows of the returned Dataframe"
@@ -1319,7 +1259,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "a6255f63",
    "metadata": {},
    "outputs": [
     {
@@ -1415,7 +1354,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e5e175b",
    "metadata": {},
    "source": [
     "Print the first row of the returned Dataframe"
@@ -1424,7 +1362,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "941570f9",
    "metadata": {},
    "outputs": [
     {

--- a/tests/integration/test_notebook.py
+++ b/tests/integration/test_notebook.py
@@ -90,8 +90,9 @@ def executed_notebook(notebook):
         if len(outputs) != len(cell.get("outputs", [])):
             cell["outputs"] = outputs
 
-        # Clear metadata like execution timestamp
+        # Clear metadata like execution timestamp and non-deterministic fields
         for cell in nb.cells:
+            cell.pop("id", None)
             cell["metadata"] = {}
 
     return nb


### PR DESCRIPTION
nbformat.v4.new_code_cell() and new_markdown_cell() automatically
assign a random id to every cell. When notebooks are regenerated,
all cells get new random IDs, causing .testout files to differ in
every cell. This made the update workflow painful: `git add -p`
required manually skipping every id-only hunk.

Strip id from cells in the three code paths that produce .testout
files (doc test fixture, integration test fixture, standalone
generator), and remove existing id fields from the 5 checked-in
notebooks that had them.

----

Prompt:
```
I update notebook changes that are needed by doing this:

1. uv run --python 3.10 --extra dev pytest docs
2. for file in **/*.testout, mv $file ($file without .testout)
3. git add -p (and don't approve any hunk that differs in only the
`id` attribute

Step 3 is the most annoying part, why do I have to handle all these
id changes? They seem randomly generated. Can we cleanup the
notebook tests to get rid of this issue?
```