### PR TITLE
CI: bump JDK from 17 to 25

### DIFF
--- a/.github/workflows/reusable-precommit.yml
+++ b/.github/workflows/reusable-precommit.yml
@@ -52,13 +52,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.cache/bazel"
-          key: ${{runner.os}}-bazel-17-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-${{ needs.get_date.outputs.ymd }}
+          key: ${{runner.os}}-bazel-25-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-${{ needs.get_date.outputs.ymd }}
           restore-keys: |
-            ${{runner.os}}-bazel-17-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-
+            ${{runner.os}}-bazel-25-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
       - name: Build JAR
         run: |
           bazel build //projects/allinone:allinone_main_deploy.jar
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
@@ -191,7 +191,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"


### PR DESCRIPTION
Batfish now requires a minimum of JDK 21 to run and prefers JDK 25.
Bump the Temurin version in the four setup-java steps and update the
matching Bazel cache-key labels accordingly.

----

Prompt:
```
The minimum JDK to run batfish now is 21, and the preferred is 25. Can you
update our docs and CI etc for this?
```

Docs required no change: pybatfish end users run Batfish via the
batfish/allinone Docker container, which bundles its own runtime, so no
host JDK requirement is documented here.
