### PR TITLE
doc_tests: run on Python 3.14 and regenerate notebooks

### DIFF
--- a/.github/workflows/reusable-precommit.yml
+++ b/.github/workflows/reusable-precommit.yml
@@ -167,7 +167,7 @@ jobs:
           java-version: "25"
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Download bf JAR
         uses: actions/download-artifact@v8
         with:

--- a/docs/source/notebooks/configProperties.ipynb
+++ b/docs/source/notebooks/configProperties.ipynb
@@ -3719,7 +3719,7 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>extended ipv4 access-list line</td>\n",
-       "      <td>blocktelnet: deny   tcp any any eq telnet</td>\n",
+       "      <td>blocktelnet: deny&nbsp;&nbsp; tcp any any eq telnet</td>\n",
        "      <td>configs/as2core1.cfg:[122]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -5476,7 +5476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/differentialQuestions.ipynb
+++ b/docs/source/notebooks/differentialQuestions.ipynb
@@ -78,7 +78,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -100,7 +100,7 @@
        "'filters-change'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -259,7 +259,7 @@
        "1  rtr-with-acl      acl_in         24  463 permit tcp 10.10.10.0/24 18.18.18.0/26 eq 8080      PERMIT                  101  2020 deny tcp any any"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -281,7 +281,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,7 +303,7 @@
        "'forwarding-change'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -512,7 +512,7 @@
        "4                    1  "
       ]
      },
-     "execution_count": 1,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -540,7 +540,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/filters.ipynb
+++ b/docs/source/notebooks/filters.ipynb
@@ -228,7 +228,7 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>['as2dept1: RESTRICT_HOST_TRAFFIC_OUT']</td>\n",
-       "      <td>deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255</td>\n",
+       "      <td>deny&nbsp;&nbsp; ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255</td>\n",
        "      <td>DENY</td>\n",
        "      <td>['permit ip any 2.128.0.0 0.0.255.255']</td>\n",
        "      <td>True</td>\n",
@@ -240,7 +240,7 @@
        "      <td>['as2dept1: RESTRICT_HOST_TRAFFIC_IN']</td>\n",
        "      <td>permit icmp any any</td>\n",
        "      <td>PERMIT</td>\n",
-       "      <td>['deny   ip any any']</td>\n",
+       "      <td>['deny&nbsp;&nbsp; ip any any']</td>\n",
        "      <td>True</td>\n",
        "      <td>BLOCKING_LINES</td>\n",
        "      <td>None</td>\n",
@@ -1238,7 +1238,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/forwarding.ipynb
+++ b/docs/source/notebooks/forwarding.ipynb
@@ -76,7 +76,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -98,7 +98,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -201,7 +201,7 @@
        "Name: Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,7 +228,7 @@
        "1"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -251,7 +251,7 @@
        "ListWrapper([((RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.11.2, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet1/0 ip 2.12.11.2)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet3/0 with resolved next-hop IP: 2.23.12.3, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet3/0 ip 2.23.12.3)]), TRANSMITTED(GigabitEthernet3/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0), DELIVERED_TO_SUBNET(Output Interface: GigabitEthernet2/0, Resolved Next Hop IP: 2.34.201.10))), ((RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.12.12.2, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0 ip 2.12.12.2)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.23.22.3, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0 ip 2.23.22.3)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0), DELIVERED_TO_SUBNET(Output Interface: GigabitEthernet2/0, Resolved Next Hop IP: 2.34.201.10)))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -281,7 +281,7 @@
        "Trace(disposition='DELIVERED_TO_SUBNET', hops=[Hop(node='as2border1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospfE2', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet1/0', ip='2.12.11.2', type='interface'), nextHopIp=None, admin=110, metric=20)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet1/0', resolvedNextHopIp='2.12.11.2', type='ForwardedOutInterface'), arpIp='2.12.11.2', outputInterface='GigabitEthernet1/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet1/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2core1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospfE2', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet3/0', ip='2.23.12.3', type='interface'), nextHopIp=None, admin=110, metric=20)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet3/0', resolvedNextHopIp='2.23.12.3', type='ForwardedOutInterface'), arpIp='2.23.12.3', outputInterface='GigabitEthernet3/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet3/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dist2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet1/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='connected', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet2/0', ip=None, type='interface'), nextHopIp=None, admin=0, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp=None, type='ForwardedOutInterface'), arpIp=None, outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED'), Step(detail=DeliveredStepDetail(outputInterface='GigabitEthernet2/0', resolvedNexthopIp='2.34.201.10'), action='DELIVERED_TO_SUBNET')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,7 +308,7 @@
        "'DELIVERED_TO_SUBNET'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -338,7 +338,7 @@
        "Hop(node='as2border1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospfE2', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet1/0', ip='2.12.11.2', type='interface'), nextHopIp=None, admin=110, metric=20)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet1/0', resolvedNextHopIp='2.12.11.2', type='ForwardedOutInterface'), arpIp='2.12.11.2', outputInterface='GigabitEthernet1/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet1/0', transformedFlow=None), action='TRANSMITTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,7 +368,7 @@
        "Hop(node='as2dist2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet1/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='connected', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet2/0', ip=None, type='interface'), nextHopIp=None, admin=0, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp=None, type='ForwardedOutInterface'), arpIp=None, outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED'), Step(detail=DeliveredStepDetail(outputInterface='GigabitEthernet2/0', resolvedNexthopIp='2.34.201.10'), action='DELIVERED_TO_SUBNET')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,7 +390,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -412,7 +412,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -517,7 +517,7 @@
        "Name: Forward_Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -544,7 +544,7 @@
        "1"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -567,7 +567,7 @@
        "ListWrapper([((RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.11.2, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet1/0 ip 2.12.11.2)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet3/0 with resolved next-hop IP: 2.23.12.3, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet3/0 ip 2.23.12.3)]), TRANSMITTED(GigabitEthernet3/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0), DELIVERED_TO_SUBNET(Output Interface: GigabitEthernet2/0, Resolved Next Hop IP: 2.34.201.10))), ((RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.12.12.2, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0 ip 2.12.12.2)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.23.22.3, Routes: [ospfE2 (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0 ip 2.23.22.3)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.34.201.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0), DELIVERED_TO_SUBNET(Output Interface: GigabitEthernet2/0, Resolved Next Hop IP: 2.34.201.10)))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -597,7 +597,7 @@
        "Trace(disposition='DELIVERED_TO_SUBNET', hops=[Hop(node='as2border1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospfE2', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet1/0', ip='2.12.11.2', type='interface'), nextHopIp=None, admin=110, metric=20)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet1/0', resolvedNextHopIp='2.12.11.2', type='ForwardedOutInterface'), arpIp='2.12.11.2', outputInterface='GigabitEthernet1/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet1/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2core1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospfE2', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet3/0', ip='2.23.12.3', type='interface'), nextHopIp=None, admin=110, metric=20)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet3/0', resolvedNextHopIp='2.23.12.3', type='ForwardedOutInterface'), arpIp='2.23.12.3', outputInterface='GigabitEthernet3/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet3/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dist2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet1/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='connected', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet2/0', ip=None, type='interface'), nextHopIp=None, admin=0, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp=None, type='ForwardedOutInterface'), arpIp=None, outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED'), Step(detail=DeliveredStepDetail(outputInterface='GigabitEthernet2/0', resolvedNexthopIp='2.34.201.10'), action='DELIVERED_TO_SUBNET')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -624,7 +624,7 @@
        "'DELIVERED_TO_SUBNET'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -654,7 +654,7 @@
        "Hop(node='as2border1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospfE2', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet1/0', ip='2.12.11.2', type='interface'), nextHopIp=None, admin=110, metric=20)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet1/0', resolvedNextHopIp='2.12.11.2', type='ForwardedOutInterface'), arpIp='2.12.11.2', outputInterface='GigabitEthernet1/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet1/0', transformedFlow=None), action='TRANSMITTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -684,7 +684,7 @@
        "Hop(node='as2dist2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet1/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='connected', network='2.34.201.0/24', nextHop=NextHopInterface(interface='GigabitEthernet2/0', ip=None, type='interface'), nextHopIp=None, admin=0, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp=None, type='ForwardedOutInterface'), arpIp=None, outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED'), Step(detail=DeliveredStepDetail(outputInterface='GigabitEthernet2/0', resolvedNexthopIp='2.34.201.10'), action='DELIVERED_TO_SUBNET')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -712,7 +712,7 @@
        "Name: Reverse_Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -739,7 +739,7 @@
        "1"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -762,7 +762,7 @@
        "ListWrapper([((RECEIVED(GigabitEthernet2/0), NO_ROUTE(Discarded)))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -792,7 +792,7 @@
        "Trace(disposition='NO_ROUTE', hops=[Hop(node='as2dist2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[], forwardingDetail=Discarded(type='Discarded'), arpIp=None, outputInterface=None), action='NO_ROUTE')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -819,7 +819,7 @@
        "'NO_ROUTE'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -849,7 +849,7 @@
        "Hop(node='as2dist2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[], forwardingDetail=Discarded(type='Discarded'), arpIp=None, outputInterface=None), action='NO_ROUTE')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -879,7 +879,7 @@
        "Hop(node='as2dist2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[], forwardingDetail=Discarded(type='Discarded'), arpIp=None, outputInterface=None), action='NO_ROUTE')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -901,7 +901,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -923,7 +923,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1033,7 +1033,7 @@
        "Name: Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1060,7 +1060,7 @@
        "7"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1083,7 +1083,7 @@
        "ListWrapper([((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.11.2, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4),ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.23.11.3, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.34.101.4, Routes: [bgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.128.0.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(eth0), PERMITTED(filter::INPUT (INGRESS_FILTER)), ACCEPTED(eth0))), ((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.11.2, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4),ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet3/0 with resolved next-hop IP: 2.23.12.3, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet3/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.34.201.4, Routes: [bgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.128.0.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(eth0), PERMITTED(filter::INPUT (INGRESS_FILTER)), ACCEPTED(eth0))), ((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.12.12.2, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4),ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.23.22.3, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.34.201.4, Routes: [bgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.128.0.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(eth0), PERMITTED(filter::INPUT (INGRESS_FILTER)), ACCEPTED(eth0))), ((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.12.12.2, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4),ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.201.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet3/0 with resolved next-hop IP: 2.23.21.3, Routes: [ibgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4)]), TRANSMITTED(GigabitEthernet3/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.34.101.4, Routes: [bgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.128.0.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(eth0), PERMITTED(filter::INPUT (INGRESS_FILTER)), ACCEPTED(eth0)))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1113,7 +1113,7 @@
        "Trace(disposition='ACCEPTED', hops=[Hop(node='as2border1', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ibgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.101.4', type='ip'), nextHopIp=None, admin=200, metric=50), RouteInfo(protocol='ibgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.201.4', type='ip'), nextHopIp=None, admin=200, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet1/0', resolvedNextHopIp='2.12.11.2', type='ForwardedOutInterface'), arpIp='2.12.11.2', outputInterface='GigabitEthernet1/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet1/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2core1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ibgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.101.4', type='ip'), nextHopIp=None, admin=200, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp='2.23.11.3', type='ForwardedOutInterface'), arpIp='2.23.11.3', outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dist1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='bgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.101.4', type='ip'), nextHopIp=None, admin=20, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp='2.34.101.4', type='ForwardedOutInterface'), arpIp='2.34.101.4', outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dept1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='connected', network='2.128.0.0/24', nextHop=NextHopInterface(interface='GigabitEthernet2/0', ip=None, type='interface'), nextHopIp=None, admin=0, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp=None, type='ForwardedOutInterface'), arpIp=None, outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='host1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='eth0', inputVrf='default'), action='RECEIVED'), Step(detail=FilterStepDetail(filter='filter::INPUT', filterType='INGRESS_FILTER', inputInterface='eth0', flow=Flow(dscp=0, dstIp='2.128.0.101', dstPort=53, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface=None, ingressNode='as2border1', ingressVrf='default', ipProtocol='UDP', packetLength=512, srcIp='10.0.0.0', srcPort=49152, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=0, tcpFlagsUrg=0)), action='PERMITTED'), Step(detail=InboundStepDetail(interface='eth0'), action='ACCEPTED')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1140,7 +1140,7 @@
        "'ACCEPTED'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1170,7 +1170,7 @@
        "Hop(node='as2border1', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ibgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.101.4', type='ip'), nextHopIp=None, admin=200, metric=50), RouteInfo(protocol='ibgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.201.4', type='ip'), nextHopIp=None, admin=200, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet1/0', resolvedNextHopIp='2.12.11.2', type='ForwardedOutInterface'), arpIp='2.12.11.2', outputInterface='GigabitEthernet1/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet1/0', transformedFlow=None), action='TRANSMITTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1200,7 +1200,7 @@
        "Hop(node='host1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='eth0', inputVrf='default'), action='RECEIVED'), Step(detail=FilterStepDetail(filter='filter::INPUT', filterType='INGRESS_FILTER', inputInterface='eth0', flow=Flow(dscp=0, dstIp='2.128.0.101', dstPort=53, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface=None, ingressNode='as2border1', ingressVrf='default', ipProtocol='UDP', packetLength=512, srcIp='10.0.0.0', srcPort=49152, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=0, tcpFlagsUrg=0)), action='PERMITTED'), Step(detail=InboundStepDetail(interface='eth0'), action='ACCEPTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1222,7 +1222,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1244,7 +1244,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1347,7 +1347,7 @@
        "Name: Forward_Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1374,7 +1374,7 @@
        "1"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1397,7 +1397,7 @@
        "ListWrapper([((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.34.101.4, Routes: [bgp (Network: 2.128.0.0/24, Next Hop: ip 2.34.101.4)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0, Routes: [connected (Network: 2.128.0.0/24, Next Hop: interface GigabitEthernet2/0)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(eth0), PERMITTED(filter::INPUT (INGRESS_FILTER)), ACCEPTED(eth0)))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1427,7 +1427,7 @@
        "Trace(disposition='ACCEPTED', hops=[Hop(node='as2dist1', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='bgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.101.4', type='ip'), nextHopIp=None, admin=20, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp='2.34.101.4', type='ForwardedOutInterface'), arpIp='2.34.101.4', outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dept1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='connected', network='2.128.0.0/24', nextHop=NextHopInterface(interface='GigabitEthernet2/0', ip=None, type='interface'), nextHopIp=None, admin=0, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp=None, type='ForwardedOutInterface'), arpIp=None, outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='host1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='eth0', inputVrf='default'), action='RECEIVED'), Step(detail=FilterStepDetail(filter='filter::INPUT', filterType='INGRESS_FILTER', inputInterface='eth0', flow=Flow(dscp=0, dstIp='2.128.0.101', dstPort=53, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface=None, ingressNode='as2dist1', ingressVrf='default', ipProtocol='UDP', packetLength=512, srcIp='2.34.101.3', srcPort=49152, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=0, tcpFlagsUrg=0)), action='PERMITTED'), Step(detail=InboundStepDetail(interface='eth0'), action='ACCEPTED')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1454,7 +1454,7 @@
        "'ACCEPTED'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1484,7 +1484,7 @@
        "Hop(node='as2dist1', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='bgp', network='2.128.0.0/24', nextHop=NextHopIp(ip='2.34.101.4', type='ip'), nextHopIp=None, admin=20, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp='2.34.101.4', type='ForwardedOutInterface'), arpIp='2.34.101.4', outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1514,7 +1514,7 @@
        "Hop(node='host1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='eth0', inputVrf='default'), action='RECEIVED'), Step(detail=FilterStepDetail(filter='filter::INPUT', filterType='INGRESS_FILTER', inputInterface='eth0', flow=Flow(dscp=0, dstIp='2.128.0.101', dstPort=53, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface=None, ingressNode='as2dist1', ingressVrf='default', ipProtocol='UDP', packetLength=512, srcIp='2.34.101.3', srcPort=49152, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=0, tcpFlagsUrg=0)), action='PERMITTED'), Step(detail=InboundStepDetail(interface='eth0'), action='ACCEPTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1542,7 +1542,7 @@
        "Name: Reverse_Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1569,7 +1569,7 @@
        "1"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1592,7 +1592,7 @@
        "ListWrapper([((ORIGINATED(default), FORWARDED(Forwarded out interface: eth0 with resolved next-hop IP: 2.128.0.1, Routes: [static (Network: 0.0.0.0/0, Next Hop: interface eth0 ip 2.128.0.1)]), PERMITTED(filter::OUTPUT (EGRESS_FILTER)), TRANSMITTED(eth0)), (RECEIVED(GigabitEthernet2/0), PERMITTED(RESTRICT_HOST_TRAFFIC_IN (INGRESS_FILTER)), FORWARDED(Forwarded out interface: GigabitEthernet0/0, Routes: [connected (Network: 2.34.101.0/24, Next Hop: interface GigabitEthernet0/0)]), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet2/0), ACCEPTED(GigabitEthernet2/0)))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1622,7 +1622,7 @@
        "Trace(disposition='ACCEPTED', hops=[Hop(node='host1', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='static', network='0.0.0.0/0', nextHop=NextHopInterface(interface='eth0', ip='2.128.0.1', type='interface'), nextHopIp=None, admin=1, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='eth0', resolvedNextHopIp='2.128.0.1', type='ForwardedOutInterface'), arpIp='2.128.0.1', outputInterface='eth0'), action='FORWARDED'), Step(detail=FilterStepDetail(filter='filter::OUTPUT', filterType='EGRESS_FILTER', inputInterface='', flow=Flow(dscp=0, dstIp='2.34.101.3', dstPort=49152, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface=None, ingressNode='host1', ingressVrf='default', ipProtocol='UDP', packetLength=512, srcIp='2.128.0.101', srcPort=53, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=0, tcpFlagsUrg=0)), action='PERMITTED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='eth0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dept1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=FilterStepDetail(filter='RESTRICT_HOST_TRAFFIC_IN', filterType='INGRESS_FILTER', inputInterface='GigabitEthernet2/0', flow=Flow(dscp=0, dstIp='2.34.101.3', dstPort=49152, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface=None, ingressNode='host1', ingressVrf='default', ipProtocol='UDP', packetLength=512, srcIp='2.128.0.101', srcPort=53, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=0, tcpFlagsUrg=0)), action='PERMITTED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='connected', network='2.34.101.0/24', nextHop=NextHopInterface(interface='GigabitEthernet0/0', ip=None, type='interface'), nextHopIp=None, admin=0, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet0/0', resolvedNextHopIp=None, type='ForwardedOutInterface'), arpIp=None, outputInterface='GigabitEthernet0/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet0/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dist1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=InboundStepDetail(interface='GigabitEthernet2/0'), action='ACCEPTED')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1649,7 +1649,7 @@
        "'ACCEPTED'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1679,7 +1679,7 @@
        "Hop(node='host1', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='static', network='0.0.0.0/0', nextHop=NextHopInterface(interface='eth0', ip='2.128.0.1', type='interface'), nextHopIp=None, admin=1, metric=0)], forwardingDetail=ForwardedOutInterface(outputInterface='eth0', resolvedNextHopIp='2.128.0.1', type='ForwardedOutInterface'), arpIp='2.128.0.1', outputInterface='eth0'), action='FORWARDED'), Step(detail=FilterStepDetail(filter='filter::OUTPUT', filterType='EGRESS_FILTER', inputInterface='', flow=Flow(dscp=0, dstIp='2.34.101.3', dstPort=49152, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface=None, ingressNode='host1', ingressVrf='default', ipProtocol='UDP', packetLength=512, srcIp='2.128.0.101', srcPort=53, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=0, tcpFlagsUrg=0)), action='PERMITTED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='eth0', transformedFlow=None), action='TRANSMITTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1709,7 +1709,7 @@
        "Hop(node='as2dist1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=InboundStepDetail(interface='GigabitEthernet2/0'), action='ACCEPTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1731,7 +1731,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1753,7 +1753,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1882,7 +1882,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1904,7 +1904,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1926,7 +1926,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2034,7 +2034,7 @@
        "Name: Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2061,7 +2061,7 @@
        "10"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2084,7 +2084,7 @@
        "ListWrapper([((RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 2.34.101.3, Routes: [bgp (Network: 1.0.1.0/24, Next Hop: ip 2.34.101.3)]), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 2.23.11.2, Routes: [ibgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet2/0), DENIED(blocktelnet (INGRESS_FILTER)))), ((RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 2.34.101.3, Routes: [bgp (Network: 1.0.1.0/24, Next Hop: ip 2.34.101.3)]), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.23.21.2, Routes: [ibgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet3/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.12.1, Routes: [ibgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 10.12.11.1, Routes: [bgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), PERMITTED(INSIDE_TO_AS1 (EGRESS_FILTER)), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0, Routes: [connected (Network: 1.0.1.0/24, Next Hop: interface GigabitEthernet0/0)]), TRANSMITTED(GigabitEthernet0/0), DELIVERED_TO_SUBNET(Output Interface: GigabitEthernet0/0, Resolved Next Hop IP: 1.0.1.3))), ((RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.34.201.3, Routes: [bgp (Network: 1.0.1.0/24, Next Hop: ip 2.34.201.3)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 2.23.22.2, Routes: [ibgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.12.1, Routes: [ibgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 10.12.11.1, Routes: [bgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), PERMITTED(INSIDE_TO_AS1 (EGRESS_FILTER)), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0, Routes: [connected (Network: 1.0.1.0/24, Next Hop: interface GigabitEthernet0/0)]), TRANSMITTED(GigabitEthernet0/0), DELIVERED_TO_SUBNET(Output Interface: GigabitEthernet0/0, Resolved Next Hop IP: 1.0.1.3))), ((RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.34.201.3, Routes: [bgp (Network: 1.0.1.0/24, Next Hop: ip 2.34.201.3)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.23.12.2, Routes: [ibgp (Network: 1.0.1.0/24, Next Hop: ip 10.12.11.1)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet3/0), DENIED(blocktelnet (INGRESS_FILTER))))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2114,7 +2114,7 @@
        "Trace(disposition='DENIED_IN', hops=[Hop(node='as2dept1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='bgp', network='1.0.1.0/24', nextHop=NextHopIp(ip='2.34.101.3', type='ip'), nextHopIp=None, admin=20, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet0/0', resolvedNextHopIp='2.34.101.3', type='ForwardedOutInterface'), arpIp='2.34.101.3', outputInterface='GigabitEthernet0/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet0/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2dist1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ibgp', network='1.0.1.0/24', nextHop=NextHopIp(ip='10.12.11.1', type='ip'), nextHopIp=None, admin=200, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet0/0', resolvedNextHopIp='2.23.11.2', type='ForwardedOutInterface'), arpIp='2.23.11.2', outputInterface='GigabitEthernet0/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet0/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2core1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=FilterStepDetail(filter='blocktelnet', filterType='INGRESS_FILTER', inputInterface='GigabitEthernet2/0', flow=Flow(dscp=0, dstIp='1.0.1.3', dstPort=23, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface='GigabitEthernet0/0', ingressNode='as2dept1', ingressVrf=None, ipProtocol='TCP', packetLength=512, srcIp='2.34.101.1', srcPort=49152, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=1, tcpFlagsUrg=0)), action='DENIED')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2141,7 +2141,7 @@
        "'DENIED_IN'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2171,7 +2171,7 @@
        "Hop(node='as2dept1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet0/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='bgp', network='1.0.1.0/24', nextHop=NextHopIp(ip='2.34.101.3', type='ip'), nextHopIp=None, admin=20, metric=50)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet0/0', resolvedNextHopIp='2.34.101.3', type='ForwardedOutInterface'), arpIp='2.34.101.3', outputInterface='GigabitEthernet0/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet0/0', transformedFlow=None), action='TRANSMITTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2201,7 +2201,7 @@
        "Hop(node='as2core1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet2/0', inputVrf='default'), action='RECEIVED'), Step(detail=FilterStepDetail(filter='blocktelnet', filterType='INGRESS_FILTER', inputInterface='GigabitEthernet2/0', flow=Flow(dscp=0, dstIp='1.0.1.3', dstPort=23, ecn=0, fragmentOffset=0, icmpCode=None, icmpVar=None, ingressInterface='GigabitEthernet0/0', ingressNode='as2dept1', ingressVrf=None, ipProtocol='TCP', packetLength=512, srcIp='2.34.101.1', srcPort=49152, tcpFlagsAck=0, tcpFlagsCwr=0, tcpFlagsEce=0, tcpFlagsFin=0, tcpFlagsPsh=0, tcpFlagsRst=0, tcpFlagsSyn=1, tcpFlagsUrg=0)), action='DENIED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2223,7 +2223,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2245,7 +2245,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2346,7 +2346,7 @@
        "Name: Flow, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2373,7 +2373,7 @@
        "3"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2396,7 +2396,7 @@
        "ListWrapper([((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 2.12.22.1, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet0/0 ip 2.12.22.1)]), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.12.21.2, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet2/0 ip 2.12.21.2)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet1/0), ACCEPTED(Loopback0))), ((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.12.1, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet1/0 ip 2.12.12.1)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet2/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.12.11.2, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet1/0 ip 2.12.11.2)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet0/0), ACCEPTED(Loopback0))), ((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet2/0 with resolved next-hop IP: 2.23.22.3, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet2/0 ip 2.23.22.3)]), TRANSMITTED(GigabitEthernet2/0)), (RECEIVED(GigabitEthernet0/0), FORWARDED(Forwarded out interface: GigabitEthernet1/0 with resolved next-hop IP: 2.23.12.2, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet1/0 ip 2.23.12.2)]), TRANSMITTED(GigabitEthernet1/0)), (RECEIVED(GigabitEthernet3/0), DENIED(blocktelnet (INGRESS_FILTER)))), ((ORIGINATED(default), FORWARDED(Forwarded out interface: GigabitEthernet3/0 with resolved next-hop IP: 2.23.21.3, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet3/0 ip 2.23.21.3)]), TRANSMITTED(GigabitEthernet3/0)), (RECEIVED(GigabitEthernet1/0), FORWARDED(Forwarded out interface: GigabitEthernet0/0 with resolved next-hop IP: 2.23.11.2, Routes: [ospf (Network: 2.1.2.1/32, Next Hop: interface GigabitEthernet0/0 ip 2.23.11.2)]), TRANSMITTED(GigabitEthernet0/0)), (RECEIVED(GigabitEthernet2/0), DENIED(blocktelnet (INGRESS_FILTER))))])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2426,7 +2426,7 @@
        "Trace(disposition='ACCEPTED', hops=[Hop(node='as2core2', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospf', network='2.1.2.1/32', nextHop=NextHopInterface(interface='GigabitEthernet0/0', ip='2.12.22.1', type='interface'), nextHopIp=None, admin=110, metric=3)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet0/0', resolvedNextHopIp='2.12.22.1', type='ForwardedOutInterface'), arpIp='2.12.22.1', outputInterface='GigabitEthernet0/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet0/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2border2', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet1/0', inputVrf='default'), action='RECEIVED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospf', network='2.1.2.1/32', nextHop=NextHopInterface(interface='GigabitEthernet2/0', ip='2.12.21.2', type='interface'), nextHopIp=None, admin=110, metric=2)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet2/0', resolvedNextHopIp='2.12.21.2', type='ForwardedOutInterface'), arpIp='2.12.21.2', outputInterface='GigabitEthernet2/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet2/0', transformedFlow=None), action='TRANSMITTED')]), Hop(node='as2core1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet1/0', inputVrf='default'), action='RECEIVED'), Step(detail=InboundStepDetail(interface='Loopback0'), action='ACCEPTED')])])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2453,7 +2453,7 @@
        "'ACCEPTED'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2483,7 +2483,7 @@
        "Hop(node='as2core2', steps=[Step(detail=OriginateStepDetail(originatingVrf='default'), action='ORIGINATED'), Step(detail=RoutingStepDetail(routes=[RouteInfo(protocol='ospf', network='2.1.2.1/32', nextHop=NextHopInterface(interface='GigabitEthernet0/0', ip='2.12.22.1', type='interface'), nextHopIp=None, admin=110, metric=3)], forwardingDetail=ForwardedOutInterface(outputInterface='GigabitEthernet0/0', resolvedNextHopIp='2.12.22.1', type='ForwardedOutInterface'), arpIp='2.12.22.1', outputInterface='GigabitEthernet0/0'), action='FORWARDED'), Step(detail=ExitOutputIfaceStepDetail(outputInterface='GigabitEthernet0/0', transformedFlow=None), action='TRANSMITTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2513,7 +2513,7 @@
        "Hop(node='as2core1', steps=[Step(detail=EnterInputIfaceStepDetail(inputInterface='GigabitEthernet1/0', inputVrf='default'), action='RECEIVED'), Step(detail=InboundStepDetail(interface='Loopback0'), action='ACCEPTED')])"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2541,7 +2541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/interacting.ipynb
+++ b/docs/source/notebooks/interacting.ipynb
@@ -303,7 +303,7 @@
        "        text-align: right;\n",
        "    }\n",
        "</style>\n",
-       "<table border=\"1\" class=\"dataframe tex2jax_ignore\">\n",
+       "<table border=\"1\" class=\"dataframe tex2jax_ignore mathjax_ignore\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
@@ -378,7 +378,7 @@
        "        text-align: right;\n",
        "    }\n",
        "</style>\n",
-       "<table border=\"1\" class=\"dataframe tex2jax_ignore\">\n",
+       "<table border=\"1\" class=\"dataframe tex2jax_ignore mathjax_ignore\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
@@ -482,7 +482,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.14.6"
   },
   "varInspector": {
    "cols": {

--- a/docs/source/notebooks/ipsec.ipynb
+++ b/docs/source/notebooks/ipsec.ipynb
@@ -69,7 +69,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -91,7 +91,7 @@
        "'hybridcloud'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -290,7 +290,7 @@
        "4  tgw-06b348adabd13452d  tgw-06b348adabd13452d[external-vpn-01c45673532d3e33e-1]   3.19.24.131                 exitgw                                 exitgw[GigabitEthernet3]   147.75.69.27  vpn-vpn-01c45673532d3e33e-1 -> Tunnel1  IPSEC_SESSION_ESTABLISHED"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -325,7 +325,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -347,7 +347,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -369,7 +369,7 @@
        "'hybridcloud'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -539,7 +539,7 @@
        "4  tgw-0888a76c8a371246d[external-vpn-0dc7abdb974ff8a69-2]  tgw-0888a76c8a371246d[vpn-vpn-0dc7abdb974ff8a69-2]                                 exitgw[GigabitEthernet3]                                     exitgw[Tunnel4]"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -570,7 +570,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -598,7 +598,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/resolvingSpecifiers.ipynb
+++ b/docs/source/notebooks/resolvingSpecifiers.ipynb
@@ -1340,7 +1340,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/routingProtocols.ipynb
+++ b/docs/source/notebooks/routingProtocols.ipynb
@@ -2048,7 +2048,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.0"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/routingTables.ipynb
+++ b/docs/source/notebooks/routingTables.ipynb
@@ -1348,7 +1348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/snapshot.ipynb
+++ b/docs/source/notebooks/snapshot.ipynb
@@ -71,7 +71,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -93,7 +93,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -232,7 +232,7 @@
        "0  ['as1border1']         None  Convert warning (redflag)  No virtual address set for VRRP on interface: 'GigabitEthernet0/0'      None           None"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -265,7 +265,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -287,7 +287,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,7 +309,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -474,7 +474,7 @@
        "4  configs/as2border2.cfg  PASSED   CISCO_IOS  ['as2border2']"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -505,7 +505,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,7 +527,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -549,7 +549,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -682,7 +682,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -710,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/topology.ipynb
+++ b/docs/source/notebooks/topology.ipynb
@@ -72,7 +72,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -94,7 +94,7 @@
        "'aristaevpn'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -250,7 +250,7 @@
        "4  dc1-leaf2a[Ethernet4]    dc1-leaf2b[Ethernet4]"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -279,7 +279,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -301,7 +301,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,7 +323,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -493,7 +493,7 @@
        "4    as1core1[GigabitEthernet0/0]     ['1.0.2.2']  as1border2[GigabitEthernet1/0]     ['1.0.2.1']"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -524,7 +524,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -552,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/vxlan_evpn.ipynb
+++ b/docs/source/notebooks/vxlan_evpn.ipynb
@@ -71,7 +71,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -93,7 +93,7 @@
        "'aristaevpn'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -291,7 +291,7 @@
        "4  dc1-leaf2b  default  10130  192.168.254.4            None  130  ['192.168.254.3', '192.168.254.6', '192.168.254.8']       4789"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -326,7 +326,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,7 +348,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -370,7 +370,7 @@
        "'aristaevpn'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -575,7 +575,7 @@
        "4  10130   dc1-svc3b  dc1-leaf2b  192.168.254.6       192.168.254.4  130         130     4789            None"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -611,7 +611,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +633,7 @@
        "'generate_questions'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -655,7 +655,7 @@
        "'aristaevpn'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -734,8 +734,8 @@
     "VRF | VRF | str\n",
     "VNI | VXLAN Segment ID | int\n",
     "Route_Distinguisher | Route distinguisher | str\n",
-    "Import_Route_Target | Import route target | str\n",
-    "Export_Route_Target | Export route target | str"
+    "Import_Route_Targets | Import route targets | List of str\n",
+    "Export_Route_Targets | Export route targets | List of str"
    ]
   },
   {
@@ -775,8 +775,8 @@
        "      <th>VRF</th>\n",
        "      <th>VNI</th>\n",
        "      <th>Route_Distinguisher</th>\n",
-       "      <th>Import_Route_Target</th>\n",
-       "      <th>Export_Route_Target</th>\n",
+       "      <th>Import_Route_Targets</th>\n",
+       "      <th>Export_Route_Targets</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -786,8 +786,8 @@
        "      <td>Tenant_A_WAN_Zone</td>\n",
        "      <td>15005</td>\n",
        "      <td>192.168.255.8:15005</td>\n",
-       "      <td>15005:15005</td>\n",
-       "      <td>15005:15005</td>\n",
+       "      <td>['15005:15005']</td>\n",
+       "      <td>['15005:15005']</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -795,8 +795,8 @@
        "      <td>Tenant_B_WAN_Zone</td>\n",
        "      <td>25021</td>\n",
        "      <td>192.168.255.8:25021</td>\n",
-       "      <td>25021:25021</td>\n",
-       "      <td>25021:25021</td>\n",
+       "      <td>['25021:25021']</td>\n",
+       "      <td>['25021:25021']</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -804,8 +804,8 @@
        "      <td>Tenant_C_WAN_Zone</td>\n",
        "      <td>35031</td>\n",
        "      <td>192.168.255.8:35031</td>\n",
-       "      <td>35031:35031</td>\n",
-       "      <td>35031:35031</td>\n",
+       "      <td>['35031:35031']</td>\n",
+       "      <td>['35031:35031']</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -813,8 +813,8 @@
        "      <td>Tenant_A_WAN_Zone</td>\n",
        "      <td>15005</td>\n",
        "      <td>192.168.255.9:15005</td>\n",
-       "      <td>15005:15005</td>\n",
-       "      <td>15005:15005</td>\n",
+       "      <td>['15005:15005']</td>\n",
+       "      <td>['15005:15005']</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -822,23 +822,23 @@
        "      <td>Tenant_B_WAN_Zone</td>\n",
        "      <td>25021</td>\n",
        "      <td>192.168.255.9:25021</td>\n",
-       "      <td>25021:25021</td>\n",
-       "      <td>25021:25021</td>\n",
+       "      <td>['25021:25021']</td>\n",
+       "      <td>['25021:25021']</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "       Node                VRF    VNI  Route_Distinguisher Import_Route_Target Export_Route_Target\n",
-       "0  dc1-bl1a  Tenant_A_WAN_Zone  15005  192.168.255.8:15005         15005:15005         15005:15005\n",
-       "1  dc1-bl1a  Tenant_B_WAN_Zone  25021  192.168.255.8:25021         25021:25021         25021:25021\n",
-       "2  dc1-bl1a  Tenant_C_WAN_Zone  35031  192.168.255.8:35031         35031:35031         35031:35031\n",
-       "3  dc1-bl1b  Tenant_A_WAN_Zone  15005  192.168.255.9:15005         15005:15005         15005:15005\n",
-       "4  dc1-bl1b  Tenant_B_WAN_Zone  25021  192.168.255.9:25021         25021:25021         25021:25021"
+       "       Node                VRF    VNI  Route_Distinguisher Import_Route_Targets Export_Route_Targets\n",
+       "0  dc1-bl1a  Tenant_A_WAN_Zone  15005  192.168.255.8:15005      ['15005:15005']      ['15005:15005']\n",
+       "1  dc1-bl1a  Tenant_B_WAN_Zone  25021  192.168.255.8:25021      ['25021:25021']      ['25021:25021']\n",
+       "2  dc1-bl1a  Tenant_C_WAN_Zone  35031  192.168.255.8:35031      ['35031:35031']      ['35031:35031']\n",
+       "3  dc1-bl1b  Tenant_A_WAN_Zone  15005  192.168.255.9:15005      ['15005:15005']      ['15005:15005']\n",
+       "4  dc1-bl1b  Tenant_B_WAN_Zone  25021  192.168.255.9:25021      ['25021:25021']      ['25021:25021']"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -862,16 +862,16 @@
     {
      "data": {
       "text/plain": [
-       "Node                              dc1-bl1a\n",
-       "VRF                      Tenant_A_WAN_Zone\n",
-       "VNI                                  15005\n",
-       "Route_Distinguisher    192.168.255.8:15005\n",
-       "Import_Route_Target            15005:15005\n",
-       "Export_Route_Target            15005:15005\n",
+       "Node                               dc1-bl1a\n",
+       "VRF                       Tenant_A_WAN_Zone\n",
+       "VNI                                   15005\n",
+       "Route_Distinguisher     192.168.255.8:15005\n",
+       "Import_Route_Targets        ['15005:15005']\n",
+       "Export_Route_Targets        ['15005:15005']\n",
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -899,7 +899,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Move the doc_tests CI job from Python 3.10 to 3.14 so the notebook
regeneration tests run on the same interpreter as the rest of the
matrix. build_docs and readthedocs_build stay on 3.10 (the latter must
match ReadTheDocs' environment).

Regenerate the checked-in notebooks against current batfish. vxlan_evpn
picks up the renamed evpnL3VniProperties columns
(Import_Route_Target/Export_Route_Target -> plural *_Route_Targets, now
List of str) from batfish/batfish#10117. The remaining notebook diffs
are the newer pandas' HTML output (non-breaking spaces, an added
mathjax_ignore table class) and the kernel version metadata bump, which
match what the 3.14 job now produces.

----

Prompt:
```
Let's swap github CI to use 3.14 for doc tests, then replace all the
notebooks with the new ones
```
